### PR TITLE
feat: avoid page reload between booking steps

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -4,6 +4,59 @@ jQuery(document).ready(function($) {
   var allSortedDates = [];        // Todas las fechas ordenadas
   var calendarStartDate, calendarEndDate, currentMonthDate, selectedDate;
 
+  // Paso 1: Verificación de DNI
+  $('#tb_dni_form').on('submit', function(e) {
+    e.preventDefault();
+    var dni = $('#tb_dni').val();
+    var email = $('#tb_email').val();
+    $('#tb_dni_response').html('');
+
+    $.ajax({
+      url: ajaxurl,
+      type: 'POST',
+      data: {
+        action: 'tb_verify_dni',
+        dni: dni,
+        email: email
+      },
+      success: function(response) {
+        if (response.success) {
+          $('#tb_summary_dni').text(dni);
+          $('#tb_summary_email').text(email);
+          $('#tb_dni_final').val(dni);
+          $('#tb_email_final').val(email);
+          $('#tb_step_dni').hide();
+          $('#tb_step_exam').show();
+          $('html, body').animate({ scrollTop: $('#tb_step_exam').offset().top }, 300);
+        } else {
+          $('#tb_dni_response').html('<p class="tb-message tb-message-error">' + response.data + '</p>');
+        }
+      },
+      error: function() {
+        $('#tb_dni_response').html('<p class="tb-message tb-message-error">Error en la verificación.</p>');
+      }
+    });
+  });
+
+  // Paso 2: Selección de fecha de examen
+  $('#tb_exam_date_form').on('submit', function(e) {
+    e.preventDefault();
+    var examDate = $('#tb_exam_date').val();
+    var minDate = $('#tb_exam_date').attr('min');
+    $('#tb_exam_response').html('');
+
+    if (!examDate || examDate < minDate) {
+      $('#tb_exam_response').html('<p class="tb-message tb-message-error">La fecha del examen no puede ser anterior a hoy.</p>');
+      return;
+    }
+
+    $('#tb_summary_exam_date').text(examDate);
+    $('#tb_exam_date_final').val(examDate);
+    $('#tb_step_exam').hide();
+    $('#tb_step_tutor').show();
+    $('html, body').animate({ scrollTop: $('#tb_step_tutor').offset().top }, 300);
+  });
+
   // Formatea fecha a YYYY-MM-DD
   function formatDate(date) {
     var d = new Date(date),

--- a/includes/Frontend/AjaxHandlers.php
+++ b/includes/Frontend/AjaxHandlers.php
@@ -16,6 +16,9 @@ class AjaxHandlers {
      * Register AJAX hooks.
      */
     public static function init() {
+        // Hook para verificación de DNI (usuarios logueados y no logueados)
+        add_action('wp_ajax_tb_verify_dni', [self::class, 'ajax_verify_dni']);
+        add_action('wp_ajax_nopriv_tb_verify_dni', [self::class, 'ajax_verify_dni']);
         // Hook para obtener franjas horarias disponibles (para usuarios logueados y no logueados)
         add_action('wp_ajax_tb_get_available_slots', [self::class, 'ajax_get_available_slots']);
         add_action('wp_ajax_nopriv_tb_get_available_slots', [self::class, 'ajax_get_available_slots']);
@@ -23,6 +26,34 @@ class AjaxHandlers {
         add_action('wp_ajax_tb_process_booking', [self::class, 'ajax_process_booking']);
         add_action('wp_ajax_nopriv_tb_process_booking', [self::class, 'ajax_process_booking']);
         error_log('TutoriasBooking: AjaxHandlers::init() - Hooks AJAX registrados.');
+    }
+
+    /**
+     * Verifica que el DNI y correo existan y no tengan cita previa.
+     * Responde con JSON para ser manejado en el frontend sin recargar la página.
+     */
+    public static function ajax_verify_dni() {
+        global $wpdb;
+
+        $dni   = isset($_POST['dni']) ? sanitize_text_field($_POST['dni']) : '';
+        $email = isset($_POST['email']) ? sanitize_email($_POST['email']) : '';
+
+        if (empty($dni) || empty($email)) {
+            wp_send_json_error('Datos incompletos.');
+        }
+
+        $table  = $wpdb->prefix . 'alumnos_reserva';
+        $alumno = $wpdb->get_row($wpdb->prepare("SELECT tiene_cita FROM {$table} WHERE dni = %s AND email = %s", $dni, $email));
+
+        if ($alumno) {
+            if (intval($alumno->tiene_cita) === 0) {
+                wp_send_json_success();
+            } else {
+                wp_send_json_error('El DNI introducido ya tiene una cita registrada. Si necesitas otra cita, por favor, contacta con la administración.');
+            }
+        } else {
+            wp_send_json_error('El DNI y el correo electrónico proporcionados no se encuentran en nuestra base de datos de alumnos de reserva. Por favor, contacta con la administración.');
+        }
     }
 
     /**

--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -26,56 +26,22 @@ function render_form_shortcode($atts = [])
 
     ob_start();
 
-    $alumnos_reserva_table = $wpdb->prefix . 'alumnos_reserva';
-    $show_dni_form = true;
-    $show_exam_date_form = false;
-    $show_tutor_selection = false;
-    $dni_verified = '';
-    $email_verified = '';
-    $exam_date_selected = '';
     $current_date = date('Y-m-d');
 
-    if (isset($_POST['tb_submit_exam_date']) && !empty($_POST['tb_exam_date'])) {
-        $dni_verified = sanitize_text_field($_POST['tb_dni_verified']);
-        $email_verified = sanitize_email($_POST['tb_email_verified']);
-        $exam_date_selected = sanitize_text_field($_POST['tb_exam_date']);
-        if ($exam_date_selected < $current_date) {
-            echo '<div class="tb-message tb-message-error">La fecha del examen no puede ser anterior a hoy.</div>';
-            $show_dni_form = false;
-            $show_exam_date_form = true;
-        } else {
-            $show_dni_form = false;
-            $show_exam_date_form = false;
-            $show_tutor_selection = true;
-        }
-    } elseif (isset($_POST['tb_submit_dni']) && !empty($_POST['tb_dni']) && !empty($_POST['tb_email'])) {
-        $dni_input   = sanitize_text_field($_POST['tb_dni']);
-        $email_input = sanitize_email($_POST['tb_email']);
-        $alumno = $wpdb->get_row($wpdb->prepare("SELECT tiene_cita FROM {$alumnos_reserva_table} WHERE dni = %s AND email = %s", $dni_input, $email_input));
-        if ($alumno) {
-            if (intval($alumno->tiene_cita) === 0) {
-                $dni_verified = $dni_input;
-                $email_verified = $email_input;
-                $show_dni_form = false;
-                $show_exam_date_form = true;
-            } else {
-                echo '<div class="tb-message tb-message-error">El DNI introducido ya tiene una cita registrada. Si necesitas otra cita, por favor, contacta con la administración.</div>';
-            }
-        } else {
-            echo '<div class="tb-message tb-message-error">El DNI y el correo electrónico proporcionados no se encuentran en nuestra base de datos de alumnos de reserva. Por favor, contacta con la administración.</div>';
-        }
-    }
+    // Contenedor principal que agrupa los tres pasos del formulario
+    echo '<div class="tb-container" ' . $container_style . '>';
 
-    if ($show_dni_form) {
-        include TB_PLUGIN_DIR . 'templates/frontend/dni-form.php';
-    }
-    if ($show_exam_date_form) {
-        include TB_PLUGIN_DIR . 'templates/frontend/exam-date-form.php';
-    }
-    if ($show_tutor_selection) {
-        $tutores = $wpdb->get_results("SELECT id, nombre FROM {$wpdb->prefix}tutores ORDER BY nombre ASC");
-        include TB_PLUGIN_DIR . 'templates/frontend/tutor-selection-calendar.php';
-    }
+    // Paso 1: Verificación de DNI
+    include TB_PLUGIN_DIR . 'templates/frontend/dni-form.php';
+
+    // Paso 2: Selección de fecha de examen (inicialmente oculto)
+    include TB_PLUGIN_DIR . 'templates/frontend/exam-date-form.php';
+
+    // Paso 3: Selección de tutor y franja horaria (inicialmente oculto)
+    $tutores = $wpdb->get_results("SELECT id, nombre FROM {$wpdb->prefix}tutores ORDER BY nombre ASC");
+    include TB_PLUGIN_DIR . 'templates/frontend/tutor-selection-calendar.php';
+
+    echo '</div>';
 
     return ob_get_clean();
 }

--- a/templates/frontend/dni-form.php
+++ b/templates/frontend/dni-form.php
@@ -1,16 +1,17 @@
-        <div class="tb-container" <?php echo $container_style; ?>>
-            <h3>Verificación de DNI</h3>
-            <form method="post">
-                <p class="tb-form-group">
-                    <label for="tb_dni">Introduce tu DNI:</label>
-                    <input type="text" id="tb_dni" name="tb_dni" required placeholder="Ej: 12345678A">
-                </p>
-                <p class="tb-form-group">
-                    <label for="tb_email">Introduce tu correo electrónico:</label>
-                    <input type="email" id="tb_email" name="tb_email" required placeholder="ejemplo@correo.com">
-                </p>
-                <p class="tb-form-actions">
-                    <input type="submit" name="tb_submit_dni" value="Verificar Datos" class="tb-button">
-                </p>
-            </form>
-        </div>
+<div id="tb_step_dni" class="tb-step">
+    <h3>Verificación de DNI</h3>
+    <div id="tb_dni_response"></div>
+    <form id="tb_dni_form">
+        <p class="tb-form-group">
+            <label for="tb_dni">Introduce tu DNI:</label>
+            <input type="text" id="tb_dni" name="tb_dni" required placeholder="Ej: 12345678A">
+        </p>
+        <p class="tb-form-group">
+            <label for="tb_email">Introduce tu correo electrónico:</label>
+            <input type="email" id="tb_email" name="tb_email" required placeholder="ejemplo@correo.com">
+        </p>
+        <p class="tb-form-actions">
+            <input type="submit" name="tb_submit_dni" value="Verificar Datos" class="tb-button">
+        </p>
+    </form>
+</div>

--- a/templates/frontend/exam-date-form.php
+++ b/templates/frontend/exam-date-form.php
@@ -1,16 +1,14 @@
-        <div class="tb-container" <?php echo $container_style; ?>>
-            <h3>Seleccionar Fecha de Examen</h3>
-            <form method="post">
-                <input type="hidden" name="tb_dni_verified" value="<?php echo esc_attr($dni_verified); ?>">
-                <input type="hidden" name="tb_email_verified" value="<?php echo esc_attr($email_verified); ?>">
-                <p class="tb-form-group">
-                    <label for="tb_exam_date">Fecha del Examen:</label>
-                    <input type="date" id="tb_exam_date" name="tb_exam_date" required
-                           min="<?php echo esc_attr($current_date); ?>"
-                           value="<?php echo esc_attr($exam_date_selected); ?>">
-                </p>
-                <p class="tb-form-actions">
-                    <input type="submit" name="tb_submit_exam_date" value="Siguiente" class="tb-button">
-                </p>
-            </form>
-        </div>
+<div id="tb_step_exam" class="tb-step" style="display:none;">
+    <h3>Seleccionar Fecha de Examen</h3>
+    <div id="tb_exam_response"></div>
+    <form id="tb_exam_date_form">
+        <p class="tb-form-group">
+            <label for="tb_exam_date">Fecha del Examen:</label>
+            <input type="date" id="tb_exam_date" name="tb_exam_date" required
+                   min="<?php echo esc_attr($current_date); ?>">
+        </p>
+        <p class="tb-form-actions">
+            <input type="submit" name="tb_submit_exam_date" value="Siguiente" class="tb-button">
+        </p>
+    </form>
+</div>

--- a/templates/frontend/tutor-selection-calendar.php
+++ b/templates/frontend/tutor-selection-calendar.php
@@ -1,16 +1,15 @@
-<div class="tb-container" <?php echo $container_style; ?>>
+<div id="tb_step_tutor" class="tb-step" style="display:none;">
     <h3>Reservar Tutoría</h3>
     <p class="tb-summary">
-        <strong>DNI:</strong> <?php echo esc_html($dni_verified); ?> |
-        <strong>Email:</strong> <?php echo esc_html($email_verified); ?> |
-        <strong>Fecha de Examen:</strong> <?php echo esc_html($exam_date_selected); ?>
+        <strong>DNI:</strong> <span id="tb_summary_dni"></span> |
+        <strong>Email:</strong> <span id="tb_summary_email"></span> |
+        <strong>Fecha de Examen:</strong> <span id="tb_summary_exam_date"></span>
     </p>
 
     <form id="tb_booking_form">
-        <input type="hidden" id="tb_dni_final" name="dni" value="<?php echo esc_attr($dni_verified); ?>">
-        <input type="hidden" id="tb_email_final" name="email" value="<?php echo esc_attr($email_verified); ?>">
-        <input type="hidden" id="tb_exam_date_final" name="exam_date"
-            value="<?php echo esc_attr($exam_date_selected); ?>">
+        <input type="hidden" id="tb_dni_final" name="dni">
+        <input type="hidden" id="tb_email_final" name="email">
+        <input type="hidden" id="tb_exam_date_final" name="exam_date">
         <?php wp_nonce_field('tb_booking_nonce', 'tb_booking_nonce_field'); ?>
         <div class="tb-tutor-selection-row">
             <div class="tb-tutor-select-wrapper">


### PR DESCRIPTION
## Summary
- render all booking steps at once
- add AJAX DNI verification to move between steps
- drive transitions with frontend JS to keep flow smooth

## Testing
- `php -l includes/Frontend/AjaxHandlers.php`
- `php -l includes/Frontend/Shortcodes.php`
- `php -l templates/frontend/dni-form.php`
- `php -l templates/frontend/exam-date-form.php`
- `php -l templates/frontend/tutor-selection-calendar.php`
- `node --check assets/js/frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68a57234a04c832fbbf223f37c25b1e9