### PR TITLE
Avoid page reload between booking steps

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -8,6 +8,10 @@
   --tb-container-max-width: 450px;
 }
 
+.tb-hidden {
+  display: none;
+}
+
 /* Contenedor base del plugin */
 .tb-container {
   width: 100%;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -4,6 +4,41 @@ jQuery(document).ready(function($) {
   var allSortedDates = [];        // Todas las fechas ordenadas
   var calendarStartDate, calendarEndDate, currentMonthDate, selectedDate;
 
+  // Paso 1: verificación de DNI sin recargar la página
+  $('#tb_dni_form').on('submit', function(e) {
+    e.preventDefault();
+    var dni = $('#tb_dni').val();
+    var email = $('#tb_email').val();
+
+    $.post(ajaxurl, { action: 'tb_verify_dni', dni: dni, email: email }, function(response) {
+      if (response.success) {
+        $('#tb_dni_step').hide();
+        $('#tb_exam_date_step').removeClass('tb-hidden').show();
+        $('#tb_dni_verified').val(dni);
+        $('#tb_email_verified').val(email);
+      } else {
+        alert(response.data);
+      }
+    });
+  });
+
+  // Paso 2: selección de fecha de examen
+  $('#tb_exam_date_form').on('submit', function(e) {
+    e.preventDefault();
+    var examDate = $('#tb_exam_date').val();
+    var minDate = $('#tb_exam_date').attr('min');
+    if (examDate < minDate) {
+      alert('La fecha del examen no puede ser anterior a hoy.');
+      return;
+    }
+    $('#tb_exam_date_step').hide();
+    $('#tb_tutor_selection_step').removeClass('tb-hidden').show();
+    $('#tb_exam_date_final').val(examDate);
+    var dni = $('#tb_dni_verified').val();
+    var email = $('#tb_email_verified').val();
+    $('#tb_summary').html('<strong>DNI:</strong> ' + dni + ' | <strong>Email:</strong> ' + email + ' | <strong>Fecha de Examen:</strong> ' + examDate);
+  });
+
   // Formatea fecha a YYYY-MM-DD
   function formatDate(date) {
     var d = new Date(date),

--- a/includes/Frontend/AjaxHandlers.php
+++ b/includes/Frontend/AjaxHandlers.php
@@ -22,7 +22,38 @@ class AjaxHandlers {
         // Hook para procesar la reserva (para usuarios logueados y no logueados)
         add_action('wp_ajax_tb_process_booking', [self::class, 'ajax_process_booking']);
         add_action('wp_ajax_nopriv_tb_process_booking', [self::class, 'ajax_process_booking']);
+        // Hook para verificar DNI y correo electrónico
+        add_action('wp_ajax_tb_verify_dni', [self::class, 'ajax_verify_dni']);
+        add_action('wp_ajax_nopriv_tb_verify_dni', [self::class, 'ajax_verify_dni']);
         error_log('TutoriasBooking: AjaxHandlers::init() - Hooks AJAX registrados.');
+    }
+
+    /**
+     * Verifica que el DNI y el correo correspondan a un alumno válido sin cita previa.
+     */
+    public static function ajax_verify_dni() {
+        global $wpdb;
+
+        $dni   = isset($_POST['dni']) ? sanitize_text_field($_POST['dni']) : '';
+        $email = isset($_POST['email']) ? sanitize_email($_POST['email']) : '';
+
+        if (empty($dni) || empty($email)) {
+            wp_send_json_error('Faltan datos para la verificación.');
+            return;
+        }
+
+        $table = $wpdb->prefix . 'alumnos_reserva';
+        $alumno = $wpdb->get_row($wpdb->prepare("SELECT tiene_cita FROM {$table} WHERE dni = %s AND email = %s", $dni, $email));
+
+        if ($alumno) {
+            if (intval($alumno->tiene_cita) === 0) {
+                wp_send_json_success(['dni' => $dni, 'email' => $email]);
+            } else {
+                wp_send_json_error('El DNI introducido ya tiene una cita registrada.');
+            }
+        } else {
+            wp_send_json_error('El DNI y el correo electrónico proporcionados no se encuentran en nuestra base de datos.');
+        }
     }
 
     /**

--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -24,58 +24,16 @@ function render_form_shortcode($atts = [])
         $container_style = 'style="max-width:' . esc_attr($atts['width']) . ';"';
     }
 
-    ob_start();
-
-    $alumnos_reserva_table = $wpdb->prefix . 'alumnos_reserva';
-    $show_dni_form = true;
-    $show_exam_date_form = false;
-    $show_tutor_selection = false;
+    $current_date = date('Y-m-d');
     $dni_verified = '';
     $email_verified = '';
     $exam_date_selected = '';
-    $current_date = date('Y-m-d');
+    $tutores = $wpdb->get_results("SELECT id, nombre FROM {$wpdb->prefix}tutores ORDER BY nombre ASC");
 
-    if (isset($_POST['tb_submit_exam_date']) && !empty($_POST['tb_exam_date'])) {
-        $dni_verified = sanitize_text_field($_POST['tb_dni_verified']);
-        $email_verified = sanitize_email($_POST['tb_email_verified']);
-        $exam_date_selected = sanitize_text_field($_POST['tb_exam_date']);
-        if ($exam_date_selected < $current_date) {
-            echo '<div class="tb-message tb-message-error">La fecha del examen no puede ser anterior a hoy.</div>';
-            $show_dni_form = false;
-            $show_exam_date_form = true;
-        } else {
-            $show_dni_form = false;
-            $show_exam_date_form = false;
-            $show_tutor_selection = true;
-        }
-    } elseif (isset($_POST['tb_submit_dni']) && !empty($_POST['tb_dni']) && !empty($_POST['tb_email'])) {
-        $dni_input   = sanitize_text_field($_POST['tb_dni']);
-        $email_input = sanitize_email($_POST['tb_email']);
-        $alumno = $wpdb->get_row($wpdb->prepare("SELECT tiene_cita FROM {$alumnos_reserva_table} WHERE dni = %s AND email = %s", $dni_input, $email_input));
-        if ($alumno) {
-            if (intval($alumno->tiene_cita) === 0) {
-                $dni_verified = $dni_input;
-                $email_verified = $email_input;
-                $show_dni_form = false;
-                $show_exam_date_form = true;
-            } else {
-                echo '<div class="tb-message tb-message-error">El DNI introducido ya tiene una cita registrada. Si necesitas otra cita, por favor, contacta con la administración.</div>';
-            }
-        } else {
-            echo '<div class="tb-message tb-message-error">El DNI y el correo electrónico proporcionados no se encuentran en nuestra base de datos de alumnos de reserva. Por favor, contacta con la administración.</div>';
-        }
-    }
-
-    if ($show_dni_form) {
-        include TB_PLUGIN_DIR . 'templates/frontend/dni-form.php';
-    }
-    if ($show_exam_date_form) {
-        include TB_PLUGIN_DIR . 'templates/frontend/exam-date-form.php';
-    }
-    if ($show_tutor_selection) {
-        $tutores = $wpdb->get_results("SELECT id, nombre FROM {$wpdb->prefix}tutores ORDER BY nombre ASC");
-        include TB_PLUGIN_DIR . 'templates/frontend/tutor-selection-calendar.php';
-    }
+    ob_start();
+    include TB_PLUGIN_DIR . 'templates/frontend/dni-form.php';
+    include TB_PLUGIN_DIR . 'templates/frontend/exam-date-form.php';
+    include TB_PLUGIN_DIR . 'templates/frontend/tutor-selection-calendar.php';
 
     return ob_get_clean();
 }

--- a/templates/frontend/dni-form.php
+++ b/templates/frontend/dni-form.php
@@ -1,6 +1,6 @@
-        <div class="tb-container" <?php echo $container_style; ?>>
+        <div id="tb_dni_step" class="tb-container" <?php echo $container_style; ?>>
             <h3>Verificación de DNI</h3>
-            <form method="post">
+            <form id="tb_dni_form" method="post">
                 <p class="tb-form-group">
                     <label for="tb_dni">Introduce tu DNI:</label>
                     <input type="text" id="tb_dni" name="tb_dni" required placeholder="Ej: 12345678A">

--- a/templates/frontend/exam-date-form.php
+++ b/templates/frontend/exam-date-form.php
@@ -1,8 +1,8 @@
-        <div class="tb-container" <?php echo $container_style; ?>>
+        <div id="tb_exam_date_step" class="tb-container tb-hidden" <?php echo $container_style; ?>>
             <h3>Seleccionar Fecha de Examen</h3>
-            <form method="post">
-                <input type="hidden" name="tb_dni_verified" value="<?php echo esc_attr($dni_verified); ?>">
-                <input type="hidden" name="tb_email_verified" value="<?php echo esc_attr($email_verified); ?>">
+            <form id="tb_exam_date_form" method="post">
+                <input type="hidden" id="tb_dni_verified" name="tb_dni_verified" value="<?php echo esc_attr($dni_verified); ?>">
+                <input type="hidden" id="tb_email_verified" name="tb_email_verified" value="<?php echo esc_attr($email_verified); ?>">
                 <p class="tb-form-group">
                     <label for="tb_exam_date">Fecha del Examen:</label>
                     <input type="date" id="tb_exam_date" name="tb_exam_date" required

--- a/templates/frontend/tutor-selection-calendar.php
+++ b/templates/frontend/tutor-selection-calendar.php
@@ -1,6 +1,6 @@
-<div class="tb-container" <?php echo $container_style; ?>>
+<div id="tb_tutor_selection_step" class="tb-container tb-hidden" <?php echo $container_style; ?>>
     <h3>Reservar Tutoría</h3>
-    <p class="tb-summary">
+    <p id="tb_summary" class="tb-summary">
         <strong>DNI:</strong> <?php echo esc_html($dni_verified); ?> |
         <strong>Email:</strong> <?php echo esc_html($email_verified); ?> |
         <strong>Fecha de Examen:</strong> <?php echo esc_html($exam_date_selected); ?>


### PR DESCRIPTION
## Summary
- handle DNI verification via AJAX for smoother step transitions
- hide and reveal form steps with CSS/JS to avoid page reloads

## Testing
- `php -l includes/Frontend/Shortcodes.php`
- `php -l includes/Frontend/AjaxHandlers.php`
- `php -l templates/frontend/dni-form.php`
- `php -l templates/frontend/exam-date-form.php`
- `php -l templates/frontend/tutor-selection-calendar.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a599f7ce54832fbec9aac1b00b0222