### PR TITLE
Expose site URL for frontend AJAX and fallback

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1,5 +1,5 @@
 jQuery(document).ready(function($) {
-  var ajaxurl = tbBooking.ajaxUrl;
+  var ajaxurl = (tbBooking && tbBooking.ajaxUrl) ? tbBooking.ajaxUrl : tbBooking.siteUrl + 'wp-admin/admin-ajax.php';
   var slotsByDate = {};           // Franjas horarias agrupadas por fecha
   var allSortedDates = [];        // Todas las fechas ordenadas
   var calendarStartDate, calendarEndDate, currentMonthDate, selectedDate;

--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -12,7 +12,8 @@ function enqueue_assets()
     wp_enqueue_script('tb-frontend', TB_PLUGIN_URL . 'assets/js/frontend.js', ['jquery'], false, true);
 
     wp_localize_script('tb-frontend', 'tbBooking', [
-        'ajaxUrl' => admin_url('admin-ajax.php')
+        'ajaxUrl' => admin_url('admin-ajax.php'),
+        'siteUrl' => trailingslashit(site_url())
     ]);
 }
 add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets', 20);


### PR DESCRIPTION
## Summary
- Localize `siteUrl` alongside `ajaxUrl` for frontend scripts
- Compute AJAX endpoint on the frontend with a fallback based on `siteUrl`

## Testing
- `php -l includes/Frontend/Shortcodes.php`
- `node --check assets/js/frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5b2d5eec8832f87a8f05789cfdc8b