### PR TITLE
Ensure plugin URLs use HTTPS

### DIFF
--- a/tutorias-booking.php
+++ b/tutorias-booking.php
@@ -23,7 +23,7 @@ if ( ! defined( 'TB_PLUGIN_FILE' ) ) {
     define( 'TB_PLUGIN_FILE', __FILE__ );
 }
 if ( ! defined( 'TB_PLUGIN_URL' ) ) {
-    define( 'TB_PLUGIN_URL', plugin_dir_url( TB_PLUGIN_FILE ) );
+    define( 'TB_PLUGIN_URL', set_url_scheme( plugin_dir_url( TB_PLUGIN_FILE ), 'https' ) );
 }
 if ( ! defined( 'TB_PLUGIN_DIR' ) ) {
     define( 'TB_PLUGIN_DIR', plugin_dir_path( TB_PLUGIN_FILE ) );


### PR DESCRIPTION
## Summary
- Force HTTPS scheme when defining `TB_PLUGIN_URL` to avoid mixed content.
- Verified CSS assets contain no insecure `url()` references.

## Testing
- `php -l tutorias-booking.php`
- `rg 'url\(' --type css`

------
https://chatgpt.com/codex/tasks/task_e_68a5b2d23a64832fa161ab3ea05c27aa