### PR TITLE
Mejora de navegación y confirmación en formularios de reserva

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -60,6 +60,28 @@
   font-weight: 600;
 }
 
+.tb-back-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5em;
+  color: var(--tb-primary-color);
+  margin-bottom: 10px;
+}
+.tb-back-button:hover {
+  color: var(--tb-primary-dark);
+}
+
+.tb-confirm-area {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin-top: 15px;
+  text-align: center;
+}
+
 /* Calendario de disponibilidad */
 .tb-calendar-month { margin-bottom: 25px; }
 .tb-calendar-month-name { font-weight: 600; }

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -67,6 +67,19 @@ jQuery(document).ready(function($) {
     });
   });
 
+  // Botones para volver al paso anterior
+  $('#tb_back_to_dni').on('click', function() {
+    $('#tb_exam_date_step').fadeOut(function() {
+      $('#tb_dni_step').fadeIn();
+    });
+  });
+
+  $('#tb_back_to_exam_date').on('click', function() {
+    $('#tb_tutor_selection_step').fadeOut(function() {
+      $('#tb_exam_date_step').fadeIn();
+    });
+  });
+
   // Paso 2: selección de fecha de examen
   $('#tb_exam_date_form').submit(function(e) {
     e.preventDefault();
@@ -85,7 +98,7 @@ jQuery(document).ready(function($) {
     $('#tb_dni_final').val(dni);
     $('#tb_email_final').val(email);
     $('#tb_exam_date_final').val(examDate);
-    $('#tb_summary').html('<strong>DNI:</strong> ' + dni + ' | <strong>Email:</strong> ' + email + ' | <strong>Fecha de Examen:</strong> ' + examDate);
+    $('#tb_summary').html('<strong>Fecha de Examen:</strong> ' + examDate);
 
     $('#tb_exam_date_step').fadeOut(function() {
       $('#tb_tutor_selection_step').removeClass('tb-hidden').hide().fadeIn();
@@ -277,7 +290,8 @@ jQuery(document).ready(function($) {
               selectedDate = null; // No preseleccionar fecha
 
               // Pintar calendario + texto del slot seleccionado
-              calendarContainer.html('<div id="tb_calendar"></div><div id="tb_selected_slot" class="tb-selected-slot"></div>');
+              calendarContainer.html('<div id="tb_calendar"></div>');
+              $('#tb_selected_slot').text('');
 
               // Crear overlay si no existe
               if (!$('#tb_slots_overlay').length) {

--- a/templates/frontend/booking-form.php
+++ b/templates/frontend/booking-form.php
@@ -23,6 +23,7 @@
 </div>
 
 <div id="tb_exam_date_step" class="tb-container tb-hidden" style="display:none;<?php echo esc_attr($container_style); ?>">
+    <button type="button" id="tb_back_to_dni" class="tb-back-button">&larr;</button>
     <h3>Seleccionar Fecha de Examen</h3>
     <form id="tb_exam_date_form" method="post">
         <input type="hidden" id="tb_dni_verified" name="tb_dni_verified" value="<?php echo esc_attr($dni_verified); ?>">
@@ -41,10 +42,9 @@
 </div>
 
 <div id="tb_tutor_selection_step" class="tb-container tb-hidden" style="display:none;<?php echo esc_attr($container_style); ?>">
+    <button type="button" id="tb_back_to_exam_date" class="tb-back-button">&larr;</button>
     <h3>Reservar Tutoría</h3>
     <p id="tb_summary" class="tb-summary">
-        <strong>DNI:</strong> <?php echo esc_html($dni_verified); ?> |
-        <strong>Email:</strong> <?php echo esc_html($email_verified); ?> |
         <strong>Fecha de Examen:</strong> <?php echo esc_html($exam_date_selected); ?>
     </p>
 
@@ -63,15 +63,15 @@
                     <?php endforeach; ?>
                 </select>
             </div>
-
-            <div class="tb-action-feedback-area">
-                <div id="tb_response_message" class="tb-message tb-hidden"></div>
-                <input type="submit" id="tb_submit_booking" value="Confirmar Reserva" class="tb-button" disabled>
-            </div>
         </div>
         <div id="tb_calendar_container" class="tb-calendar-container">
             <p>Selecciona un tutor para ver las franjas horarias disponibles.</p>
         </div>
+        <div id="tb_confirmation_area" class="tb-confirm-area">
+            <span id="tb_selected_slot" class="tb-selected-slot"></span>
+            <input type="submit" id="tb_submit_booking" value="Confirmar Reserva" class="tb-button" disabled>
+        </div>
+        <div id="tb_response_message" class="tb-message tb-hidden"></div>
     </form>
     <div id="tb_booking_details_container"></div>
 </div>


### PR DESCRIPTION
## Resumen
- Mostrar solo la fecha seleccionada en el resumen final
- Mover el botón **Confirmar Reserva** debajo del calendario junto a la fecha elegida
- Añadir flechas para volver al paso anterior en los formularios

## Pruebas
- `php -l templates/frontend/booking-form.php`
- `node --check assets/js/frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6de90afd8832f824bb38d0cc7fc08