### PR TITLE
Add isolated widget using Shadow DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Este proyecto es un plugin de WordPress para gestionar la reserva de tutorías d
    Por defecto, el formulario ocupa un ancho máximo de **450px**, pero puedes ajustarlo usando el atributo opcional
    `width`, por ejemplo: ` [formulario_dni width="400px"] ` o ` [formulario_dni width="50%"] `.
 
+4. Para mostrar contenido con estilos completamente aislados, utiliza el shortcode:
+   ```
+   [tb_widget_aislado]Tu contenido[/tb_widget_aislado]
+   ```
+   Este shortcode renderiza un pequeño "card" dentro de un Web Component con **Shadow DOM**, evitando que estilos globales (p.ej. de Elementor) afecten a su presentación.
+
 ## Estructura del proyecto
 ```
 assets/      CSS y JavaScript del frontend y del área de administración.

--- a/assets/js/tb-widget-aislado.js
+++ b/assets/js/tb-widget-aislado.js
@@ -1,0 +1,18 @@
+class TBWidgetAislado extends HTMLElement {
+  constructor() {
+    super();
+    const root = this.attachShadow({ mode: 'open' });
+    root.innerHTML = `
+      <style>
+        :host { display:block; font:14px/1.4 system-ui, sans-serif; }
+        .card { padding:16px; border:1px solid #ddd; border-radius:8px; }
+        .title { margin:0 0 8px; font-weight:600; }
+      </style>
+      <div class="card">
+        <h3 class="title">Contenido aislado</h3>
+        <div class="content"><slot></slot></div>
+      </div>
+    `;
+  }
+}
+customElements.define('tb-widget-aislado', TBWidgetAislado);

--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -74,3 +74,29 @@ function render_form_shortcode($atts = [])
     return ob_get_clean();
 }
 add_shortcode('formulario_dni', __NAMESPACE__ . '\\render_form_shortcode');
+
+/**
+ * Enqueue the JavaScript for the isolated widget web component.
+ */
+function enqueue_isolated_widget_script()
+{
+    $js_rel = 'assets/js/tb-widget-aislado.js';
+    wp_register_script(
+        'tb-widget-aislado',
+        plugins_url($js_rel, TB_PLUGIN_FILE),
+        [],
+        filemtime(TB_PLUGIN_DIR . $js_rel),
+        true
+    );
+}
+add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_isolated_widget_script');
+
+/**
+ * Render shortcode that wraps content in a Shadow DOM web component.
+ */
+function render_isolated_widget_shortcode($atts = [], $content = '')
+{
+    wp_enqueue_script('tb-widget-aislado');
+    return '<tb-widget-aislado>' . do_shortcode($content) . '</tb-widget-aislado>';
+}
+add_shortcode('tb_widget_aislado', __NAMESPACE__ . '\\render_isolated_widget_shortcode');


### PR DESCRIPTION
## Summary
- add `tb_widget_aislado` shortcode and script enqueueing
- implement `TBWidgetAislado` web component with Shadow DOM
- document isolated widget shortcode usage

## Testing
- `php -l includes/Frontend/Shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a70d105edc832fa1447220d1268f94