### PR TITLE
Enable sendUpdates to trigger calendar notifications

### DIFF
--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -78,7 +78,14 @@ class CalendarService {
             'conferenceData' => ['createRequest'=>['requestId'=>uniqid(),'conferenceSolutionKey'=>['type'=>'hangoutsMeet']]]
         ]);
         try {
-            return $service->events->insert($calendarId, $event, ['conferenceDataVersion'=>1]);
+            return $service->events->insert(
+                $calendarId,
+                $event,
+                [
+                    'conferenceDataVersion' => 1,
+                    'sendUpdates' => 'all',
+                ]
+            );
         } catch (\Exception $e) {
             return null;
         }


### PR DESCRIPTION
## Summary
- add `sendUpdates=all` when inserting Google Calendar events so attendees receive notifications

## Testing
- `php -l includes/Google/CalendarService.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68a81ba4c194832fb111c4b2dc9917e5