### PR TITLE
Add tutor Google Calendar connect shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Este proyecto es un plugin de WordPress para gestionar la reserva de tutorías d
    Por defecto, el formulario ocupa un ancho máximo de **450px**, pero puedes ajustarlo usando el atributo opcional
    `width`, por ejemplo: ` [formulario_dni width="400px"] ` o ` [formulario_dni width="50%"] `.
 
+4. Para que los tutores conecten su calendario desde el frontend, inserta el shortcode:
+   ```
+   [tutor_connect]
+   ```
+   Tras introducir su correo, el tutor podrá autorizar el acceso a su Google Calendar.
+
 ## Estructura del proyecto
 ```
 assets/      CSS y JavaScript del frontend y del área de administración.

--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -74,3 +74,44 @@ function render_form_shortcode($atts = [])
     return ob_get_clean();
 }
 add_shortcode('formulario_dni', __NAMESPACE__ . '\\render_form_shortcode');
+
+function render_tutor_connect_shortcode($atts = [])
+{
+    global $wpdb;
+
+    $atts = shortcode_atts([
+        'width' => ''
+    ], $atts, 'tutor_connect');
+
+    $container_style = '';
+    if (!empty($atts['width'])) {
+        $container_style = 'max-width:' . esc_attr($atts['width']) . ';';
+    }
+
+    $tutor_id    = 0;
+    $auth_url    = '';
+    $message     = '';
+    $message_type = '';
+
+    if (isset($_GET['google_auth']) && $_GET['google_auth'] === 'success') {
+        $message = 'Cuenta conectada correctamente.';
+        $message_type = 'success';
+    } elseif (!empty($_POST['tb_tutor_email']) && isset($_POST['tb_tutor_connect_nonce']) && wp_verify_nonce($_POST['tb_tutor_connect_nonce'], 'tb_tutor_connect')) {
+        $email = sanitize_email($_POST['tb_tutor_email']);
+        $tutor_id = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$wpdb->prefix}tutores WHERE email = %s", $email));
+        if ($tutor_id) {
+            $auth_url = add_query_arg([
+                'action'   => 'tb_auth_google',
+                'tutor_id' => $tutor_id
+            ], home_url());
+        } else {
+            $message = 'Correo no encontrado.';
+            $message_type = 'error';
+        }
+    }
+
+    ob_start();
+    include TB_PLUGIN_DIR . 'templates/frontend/tutor-connect-form.php';
+    return ob_get_clean();
+}
+add_shortcode('tutor_connect', __NAMESPACE__ . '\\render_tutor_connect_shortcode');

--- a/includes/Google/GoogleClient.php
+++ b/includes/Google/GoogleClient.php
@@ -95,7 +95,10 @@ class GoogleClient {
                 $tokens = $client->getAccessToken();
                 if (isset($tokens['access_token'])) {
                     self::save_tokens($tutor_id, $tokens['access_token'], $tokens['refresh_token'] ?? null, $tokens['expires_in']);
-                    wp_redirect(admin_url('admin.php?page=tb-tutores&message=google_auth_success'));
+                    $redirect = is_admin()
+                        ? admin_url('admin.php?page=tb-tutores&message=google_auth_success')
+                        : home_url('?google_auth=success');
+                    wp_redirect($redirect);
                     exit;
                 } else {
                     wp_die('No se pudo obtener el token de acceso de Google.');
@@ -108,3 +111,4 @@ class GoogleClient {
 }
 
 add_action('admin_init', [GoogleClient::class, 'handle_oauth']);
+add_action('init', [GoogleClient::class, 'handle_oauth']);

--- a/templates/frontend/tutor-connect-form.php
+++ b/templates/frontend/tutor-connect-form.php
@@ -1,0 +1,23 @@
+<div class="tb-container" <?php echo $container_style; ?>>
+    <h3>Conectar Tutor</h3>
+    <?php if (!empty($message)): ?>
+        <p class="tb-message tb-message-<?php echo esc_attr($message_type); ?>"><?php echo esc_html($message); ?></p>
+    <?php endif; ?>
+
+    <?php if ($auth_url): ?>
+        <p class="tb-form-actions">
+            <a class="tb-button" href="<?php echo esc_url($auth_url); ?>">Conectar con Google Calendar</a>
+        </p>
+    <?php else: ?>
+        <form method="post">
+            <?php wp_nonce_field('tb_tutor_connect', 'tb_tutor_connect_nonce'); ?>
+            <p class="tb-form-group">
+                <label for="tb_tutor_email">Correo electrónico:</label>
+                <input type="email" id="tb_tutor_email" name="tb_tutor_email" required>
+            </p>
+            <p class="tb-form-actions">
+                <input type="submit" class="tb-button" value="Verificar correo">
+            </p>
+        </form>
+    <?php endif; ?>
+</div>


### PR DESCRIPTION
## Summary
- add `[tutor_connect]` shortcode and template for tutors to authorize Google Calendar via email
- handle OAuth on frontend and redirect after successful connection
- document tutor connection shortcode in README

## Testing
- `php -l includes/Google/GoogleClient.php`
- `php -l includes/Frontend/Shortcodes.php`
- `php -l templates/frontend/tutor-connect-form.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68a82b268ea0832f904aff1632646f3a