### PR TITLE
Authenticate tutor connection via Google email

### DIFF
--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -88,26 +88,16 @@ function render_tutor_connect_shortcode($atts = [])
         $container_style = 'max-width:' . esc_attr($atts['width']) . ';';
     }
 
-    $tutor_id    = 0;
-    $auth_url    = '';
+    $auth_url    = add_query_arg(['action' => 'tb_auth_google'], home_url());
     $message     = '';
     $message_type = '';
 
     if (isset($_GET['google_auth']) && $_GET['google_auth'] === 'success') {
         $message = 'Cuenta conectada correctamente.';
         $message_type = 'success';
-    } elseif (!empty($_POST['tb_tutor_email']) && isset($_POST['tb_tutor_connect_nonce']) && wp_verify_nonce($_POST['tb_tutor_connect_nonce'], 'tb_tutor_connect')) {
-        $email = sanitize_email($_POST['tb_tutor_email']);
-        $tutor_id = $wpdb->get_var($wpdb->prepare("SELECT id FROM {$wpdb->prefix}tutores WHERE email = %s", $email));
-        if ($tutor_id) {
-            $auth_url = add_query_arg([
-                'action'   => 'tb_auth_google',
-                'tutor_id' => $tutor_id
-            ], home_url());
-        } else {
-            $message = 'Correo no encontrado.';
-            $message_type = 'error';
-        }
+    } elseif (isset($_GET['google_auth']) && $_GET['google_auth'] === 'not_found') {
+        $message = 'Usuario no se encuentra en la base de datos.';
+        $message_type = 'error';
     }
 
     ob_start();

--- a/templates/frontend/tutor-connect-form.php
+++ b/templates/frontend/tutor-connect-form.php
@@ -4,20 +4,7 @@
         <p class="tb-message tb-message-<?php echo esc_attr($message_type); ?>"><?php echo esc_html($message); ?></p>
     <?php endif; ?>
 
-    <?php if ($auth_url): ?>
-        <p class="tb-form-actions">
-            <a class="tb-button" href="<?php echo esc_url($auth_url); ?>">Conectar con Google Calendar</a>
-        </p>
-    <?php else: ?>
-        <form method="post">
-            <?php wp_nonce_field('tb_tutor_connect', 'tb_tutor_connect_nonce'); ?>
-            <p class="tb-form-group">
-                <label for="tb_tutor_email">Correo electrónico:</label>
-                <input type="email" id="tb_tutor_email" name="tb_tutor_email" required>
-            </p>
-            <p class="tb-form-actions">
-                <input type="submit" class="tb-button" value="Verificar correo">
-            </p>
-        </form>
-    <?php endif; ?>
+    <p class="tb-form-actions">
+        <a class="tb-button" href="<?php echo esc_url($auth_url); ?>">Conectar con Google Calendar</a>
+    </p>
 </div>


### PR DESCRIPTION
## Summary
- Remove manual email step from tutor connect shortcode and show direct connect button
- Look up tutor via Google account email after OAuth and save tokens when found
- Indicate when a Google account is not associated with a tutor

## Testing
- `php -l includes/Frontend/Shortcodes.php`
- `php -l templates/frontend/tutor-connect-form.php`
- `php -l includes/Google/GoogleClient.php`
- `composer install` *(fails: curl error 56 while downloading https://api.github.com)*


------
https://chatgpt.com/codex/tasks/task_e_68a8323c60c8832fb77425db518d9ab3