### PR TITLE
Add tutor availability assignment

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,9 +1,3 @@
-.tb-admin-wrapper {
-    max-width: 900px;
-    padding: 20px;
-    background: #fff;
-}
-
 .tb-title {
     font-size: 26px;
     margin-bottom: 10px;
@@ -94,4 +88,28 @@
     margin: 0 auto; /* Esto centra el contenedor horizontalmente */
     padding: 20px;
     background: #fff;
+}
+
+.tb-card {
+    background: #f9f9f9;
+    padding: 20px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    max-width: 500px;
+}
+#tb-calendar {
+    margin-top: 15px;
+}
+#tb-selected-dates {
+    list-style: none;
+    padding: 0;
+    margin-top: 10px;
+}
+#tb-selected-dates li {
+    display: inline-block;
+    background: #2271b1;
+    color: #fff;
+    padding: 2px 6px;
+    border-radius: 3px;
+    margin: 2px;
 }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,1 +1,30 @@
 // admin js
+jQuery(function($){
+    var $cal = $('#tb-calendar');
+    if (!$cal.length || typeof $.fn.datepicker !== 'function') {
+        return;
+    }
+
+    var dates = [];
+    $cal.datepicker({
+        dateFormat: 'yy-mm-dd',
+        onSelect: function(dateText) {
+            var idx = dates.indexOf(dateText);
+            if (idx >= 0) {
+                dates.splice(idx, 1);
+            } else {
+                dates.push(dateText);
+            }
+            render();
+        }
+    });
+
+    function render() {
+        var $list = $('#tb-selected-dates').empty();
+        var $hidden = $('#tb-hidden-dates').empty();
+        dates.forEach(function(d){
+            $list.append('<li>'+d+'</li>');
+            $hidden.append('<input type="hidden" name="tb_dates[]" value="'+d+'">');
+        });
+    }
+});

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -22,6 +22,8 @@ class AdminMenu {
             return;
         }
         wp_enqueue_style('tb-admin', TB_PLUGIN_URL . 'assets/css/admin.css');
-        wp_enqueue_script('tb-admin', TB_PLUGIN_URL . 'assets/js/admin.js', ['jquery'], false, true);
+        wp_enqueue_style('tb-jquery-ui', 'https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css');
+        wp_enqueue_script('jquery-ui-datepicker');
+        wp_enqueue_script('tb-admin', TB_PLUGIN_URL . 'assets/js/admin.js', ['jquery', 'jquery-ui-datepicker'], false, true);
     }
 }

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -38,6 +38,8 @@
                         <td><?php echo $est; ?></td>
                         <td>
                             <a href="<?php echo esc_url($url); ?>" class="tb-link">Conectar Calendar</a>
+                            <?php $disp = admin_url("admin.php?page=tb-tutores&action=tb_assign_availability&tutor_id={$t->id}"); ?>
+                            <a href="<?php echo esc_url($disp); ?>" class="tb-link">Asignar Disponibilidad</a>
                             <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este tutor?');">
                                 <input type="hidden" name="tb_delete_tutor_id" value="<?php echo esc_attr($t->id); ?>">
                                 <button type="submit" class="tb-button tb-button-danger">Eliminar</button>

--- a/templates/admin/assign-availability.php
+++ b/templates/admin/assign-availability.php
@@ -1,0 +1,23 @@
+<?php /** @var array $messages */ ?>
+<div class="tb-admin-wrapper">
+    <?php foreach ($messages as $msg): ?>
+        <div class="<?php echo $msg['type'] === 'success' ? 'notice-success' : 'notice-error'; ?> notice is-dismissible tb-notice">
+            <p><?php echo esc_html($msg['text']); ?></p>
+        </div>
+    <?php endforeach; ?>
+
+    <div class="tb-card">
+        <h2>Asignar Disponibilidad a <?php echo esc_html($tutor->nombre); ?></h2>
+        <form method="POST">
+            <label for="tb-start">Inicio</label>
+            <input id="tb-start" type="time" name="tb_start_time" required>
+            <label for="tb-end">Fin</label>
+            <input id="tb-end" type="time" name="tb_end_time" required>
+            <div id="tb-calendar"></div>
+            <ul id="tb-selected-dates"></ul>
+            <div id="tb-hidden-dates"></div>
+            <button type="submit" name="tb_assign_availability" class="tb-button">Guardar</button>
+            <a href="<?php echo esc_url(admin_url('admin.php?page=tb-tutores')); ?>" class="tb-button">Volver</a>
+        </form>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add "Asignar Disponibilidad" link for each tutor
- allow admins to select time range and days to create DISPONIBLE events
- include datepicker assets and styling for availability card

## Testing
- `php -l includes/Admin/AdminController.php`
- `php -l includes/Admin/AdminMenu.php`
- `php -l templates/admin/admin-page.php`
- `php -l templates/admin/assign-availability.php`


------
https://chatgpt.com/codex/tasks/task_e_68a84565ac5c832fb3c33d7ca36b820d