### PR TITLE
Disable selection of existing availability days

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -100,6 +100,11 @@
 #tb-calendar {
     margin-top: 15px;
 }
+#tb-calendar .tb-date-unavailable a {
+    background: #e0e0e0 !important;
+    color: #777 !important;
+    cursor: default !important;
+}
 #tb-selected-dates {
     list-style: none;
     padding: 0;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -6,9 +6,18 @@ jQuery(function($){
     }
 
     var dates = [];
+    var unavailable = window.tbExistingAvailabilityDates || [];
     $cal.datepicker({
         dateFormat: 'yy-mm-dd',
+        beforeShowDay: function(date) {
+            var d = $.datepicker.formatDate('yy-mm-dd', date);
+            var isUnavailable = unavailable.indexOf(d) >= 0;
+            return [!isUnavailable, isUnavailable ? 'tb-date-unavailable' : ''];
+        },
         onSelect: function(dateText) {
+            if (unavailable.indexOf(dateText) >= 0) {
+                return;
+            }
             var idx = dates.indexOf(dateText);
             if (idx >= 0) {
                 dates.splice(idx, 1);

--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -186,6 +186,22 @@ class AdminController {
             }
         }
 
+        $existing_dates = [];
+        $start_range = date('Y-m-d');
+        $end_range   = date('Y-m-d', strtotime('+1 year'));
+        $existing_events = CalendarService::get_available_calendar_events($tutor_id, $start_range, $end_range);
+        foreach ($existing_events as $event) {
+            $start_obj = $event->getStart();
+            $date_str  = $start_obj->getDate();
+            if (!$date_str) {
+                $date_str = substr($start_obj->getDateTime(), 0, 10);
+            }
+            if ($date_str) {
+                $existing_dates[] = $date_str;
+            }
+        }
+        $existing_dates = array_values(array_unique($existing_dates));
+
         include TB_PLUGIN_DIR . 'templates/admin/assign-availability.php';
     }
 

--- a/templates/admin/assign-availability.php
+++ b/templates/admin/assign-availability.php
@@ -1,4 +1,7 @@
 <?php /** @var array $messages */ ?>
+<script>
+    var tbExistingAvailabilityDates = <?php echo wp_json_encode($existing_dates); ?>;
+</script>
 <div class="tb-admin-wrapper">
     <?php foreach ($messages as $msg): ?>
         <div class="<?php echo $msg['type'] === 'success' ? 'notice-success' : 'notice-error'; ?> notice is-dismissible tb-notice">


### PR DESCRIPTION
## Summary
- Avoid assigning availability on days that are already marked as available.
- Expose existing availability dates to admin calendar and style disabled days.
- Prevent selection of disabled days in admin datepicker.

## Testing
- `composer validate`
- `php -l includes/Admin/AdminController.php`
- `php -l templates/admin/assign-availability.php`


------
https://chatgpt.com/codex/tasks/task_e_68a848c47978832fb1e9a31554c22206