### PR TITLE
feat: allow assigning tutor availability

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -95,3 +95,17 @@
     padding: 20px;
     background: #fff;
 }
+
+.tb-card {
+    border: 1px solid #ddd;
+    padding: 20px;
+    margin-top: 20px;
+    border-radius: 6px;
+    background: #fff;
+}
+
+#tb-selected-dates {
+    margin-top: 10px;
+    padding-left: 20px;
+    list-style: disc;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,1 +1,106 @@
-// admin js
+jQuery(function($){
+    if (!$('#tb-calendar').length) {
+        return;
+    }
+
+    var existing = Array.isArray(window.tbExistingAvailabilityDates) ? window.tbExistingAvailabilityDates : [];
+    var selected = [];
+    var startDate = new Date();
+    startDate.setHours(0,0,0,0);
+    var endDate = new Date();
+    endDate.setMonth(endDate.getMonth() + 3);
+    endDate.setHours(0,0,0,0);
+    var current = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
+
+    function formatDate(d) {
+        var month = '' + (d.getMonth() + 1);
+        var day = '' + d.getDate();
+        var year = d.getFullYear();
+        if (month.length < 2) month = '0' + month;
+        if (day.length < 2) day = '0' + day;
+        return [year, month, day].join('-');
+    }
+
+    function refreshSelected() {
+        var list = $('#tb-selected-dates').empty();
+        var hidden = $('#tb-hidden-dates').empty();
+        selected.sort();
+        selected.forEach(function(d){
+            list.append('<li>' + d + '</li>');
+            hidden.append('<input type="hidden" name="tb_dates[]" value="' + d + '">');
+        });
+    }
+
+    function renderCalendar(monthDate) {
+        var calendar = $('#tb-calendar');
+        var month = monthDate.getMonth();
+        var year = monthDate.getFullYear();
+        var monthNames = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
+        var dayNames = ['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'];
+
+        var html = '<div class="tb-calendar-month">';
+        html += '<div class="tb-calendar-nav">';
+        var prevDisabled = (monthDate.getFullYear() === startDate.getFullYear() && monthDate.getMonth() <= startDate.getMonth());
+        var nextDisabled = (monthDate.getFullYear() === endDate.getFullYear() && monthDate.getMonth() >= endDate.getMonth());
+        html += '<button id="tb_prev_month" class="tb-nav-btn"' + (prevDisabled ? ' disabled' : '') + '>&lt;</button>';
+        html += '<span class="tb-calendar-month-name">' + monthNames[month] + ' ' + year + '</span>';
+        html += '<button id="tb_next_month" class="tb-nav-btn"' + (nextDisabled ? ' disabled' : '') + '>&gt;</button>';
+        html += '</div>';
+
+        html += '<div class="tb-calendar-week-day-names">';
+        dayNames.forEach(function(d){ html += '<div class="tb-calendar-week-day">' + d + '</div>'; });
+        html += '</div>';
+
+        html += '<div class="tb-calendar-days">';
+        var firstDayIndex = new Date(year, month, 1).getDay();
+        for (var i=0; i<firstDayIndex; i++) {
+            html += '<div class="tb-calendar-day tb-empty"></div>';
+        }
+        var daysInMonth = new Date(year, month + 1, 0).getDate();
+        for (var d=1; d<=daysInMonth; d++) {
+            var dateObj = new Date(year, month, d);
+            var dateStr = formatDate(dateObj);
+            var classes = 'tb-calendar-day';
+            if (dateObj < startDate || dateObj > endDate || existing.indexOf(dateStr) !== -1) {
+                classes += ' tb-day-unavailable';
+            } else {
+                classes += ' tb-day-available';
+                if (selected.indexOf(dateStr) !== -1) {
+                    classes += ' tb-selected';
+                }
+            }
+            html += '<div class="' + classes + '" data-date="' + dateStr + '">' + d + '</div>';
+        }
+        html += '</div></div>';
+        calendar.html(html);
+    }
+
+    $('#tb-calendar').on('click', '.tb-calendar-day.tb-day-available', function(){
+        var date = $(this).data('date');
+        var idx = selected.indexOf(date);
+        if (idx > -1) {
+            selected.splice(idx,1);
+            $(this).removeClass('tb-selected');
+        } else {
+            selected.push(date);
+            $(this).addClass('tb-selected');
+        }
+        refreshSelected();
+    });
+
+    $('#tb-calendar').on('click', '#tb_prev_month', function(){
+        if ($(this).prop('disabled')) return;
+        current.setMonth(current.getMonth() - 1);
+        renderCalendar(current);
+    });
+
+    $('#tb-calendar').on('click', '#tb_next_month', function(){
+        if ($(this).prop('disabled')) return;
+        current.setMonth(current.getMonth() + 1);
+        renderCalendar(current);
+    });
+
+    renderCalendar(current);
+    refreshSelected();
+});
+

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -22,6 +22,9 @@ class AdminMenu {
             return;
         }
         wp_enqueue_style('tb-admin', TB_PLUGIN_URL . 'assets/css/admin.css');
+        if (isset($_GET['action']) && $_GET['action'] === 'tb_assign_availability') {
+            wp_enqueue_style('tb-frontend', TB_PLUGIN_URL . 'assets/css/frontend.css');
+        }
         wp_enqueue_script('tb-admin', TB_PLUGIN_URL . 'assets/js/admin.js', ['jquery'], false, true);
     }
 }

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -32,12 +32,15 @@
                     <?php $tok = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}tutores_tokens WHERE tutor_id=%d", $t->id)); ?>
                     <?php $est = $tok ? '✅ Conectado' : '❌ No conectado'; ?>
                     <?php $url = admin_url("admin.php?page=tb-tutores&action=tb_auth_google&tutor_id={$t->id}"); ?>
+                    <?php $avail_url = admin_url("admin.php?page=tb-tutores&action=tb_assign_availability&tutor_id={$t->id}"); ?>
                     <tr>
                         <td><?php echo esc_html($t->nombre); ?></td>
                         <td><?php echo esc_html($t->email); ?></td>
                         <td><?php echo $est; ?></td>
                         <td>
                             <a href="<?php echo esc_url($url); ?>" class="tb-link">Conectar Calendar</a>
+                            <span> | </span>
+                            <a href="<?php echo esc_url($avail_url); ?>" class="tb-link">Asignar Disponibilidad</a>
                             <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este tutor?');">
                                 <input type="hidden" name="tb_delete_tutor_id" value="<?php echo esc_attr($t->id); ?>">
                                 <button type="submit" class="tb-button tb-button-danger">Eliminar</button>


### PR DESCRIPTION
## Summary
- allow tutors to be assigned availability slots from admin table
- render calendar in admin to pick days excluding existing availability
- load frontend styles when assigning availability

## Testing
- `php -l includes/Admin/AdminMenu.php`
- `php -l includes/Admin/AdminController.php`
- `php -l templates/admin/admin-page.php`
- `php -l templates/admin/assign-availability.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8521a6690832f80064f0721b67aba