### PR TITLE
Add multi-slot availability and edit options

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -109,3 +109,52 @@
     padding-left: 20px;
     list-style: disc;
 }
+
+.tb-time-slot {
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.tb-time-slot button {
+    margin-left: 5px;
+}
+
+.tb-calendar-day.tb-day-has-availability {
+    position: relative;
+    justify-content: center;
+}
+
+.tb-day-number {
+    flex: 1;
+    text-align: center;
+}
+
+.tb-day-dots {
+    position: absolute;
+    right: 4px;
+    top: 2px;
+    cursor: pointer;
+}
+
+.tb-day-menu {
+    position: absolute;
+    background: #fff;
+    border: 1px solid #ccc;
+    z-index: 1000;
+}
+
+.tb-day-menu button {
+    display: block;
+    width: 100%;
+    padding: 5px 10px;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+}
+
+.tb-day-menu button:hover {
+    background: #f0f0f0;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -3,13 +3,38 @@ jQuery(function($){
         return;
     }
 
-    var existing = Array.isArray(window.tbExistingAvailabilityDates) ? window.tbExistingAvailabilityDates : [];
+    var existingDates = Array.isArray(window.tbExistingAvailabilityDates) ? window.tbExistingAvailabilityDates : [];
+    var existingSlots = window.tbExistingAvailabilitySlots || {};
     var selected = [];
-    var startDate = new Date();
-    startDate.setHours(0,0,0,0);
-    var endDate = new Date();
-    endDate.setMonth(endDate.getMonth() + 3);
-    endDate.setHours(0,0,0,0);
+
+    function addSlot(start, end) {
+        start = start || '';
+        end = end || '';
+        var container = $('#tb-time-slots');
+        var slot = $('<div class="tb-time-slot">'
+            + '<label>Inicio</label><input type="time" name="tb_start_time[]" value="'+start+'" required>'
+            + '<label>Fin</label><input type="time" name="tb_end_time[]" value="'+end+'" required>'
+            + '<button type="button" class="tb-button tb-add-slot">+</button>'
+            + '</div>');
+        if (container.find('.tb-add-slot').length) {
+            container.find('.tb-add-slot').last().removeClass('tb-add-slot').addClass('tb-remove-slot').text('-');
+        }
+        container.append(slot);
+    }
+
+    $('#tb-time-slots').on('click', '.tb-add-slot', function(){
+        addSlot();
+    });
+
+    $('#tb-time-slots').on('click', '.tb-remove-slot', function(){
+        $(this).closest('.tb-time-slot').remove();
+        if ($('#tb-time-slots .tb-add-slot').length === 0) {
+            $('#tb-time-slots .tb-time-slot').last().find('button').removeClass('tb-remove-slot').addClass('tb-add-slot').text('+');
+        }
+    });
+
+    var startDate = new Date(); startDate.setHours(0,0,0,0);
+    var endDate = new Date(); endDate.setMonth(endDate.getMonth() + 3); endDate.setHours(0,0,0,0);
     var current = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
 
     function formatDate(d) {
@@ -61,15 +86,19 @@ jQuery(function($){
             var dateObj = new Date(year, month, d);
             var dateStr = formatDate(dateObj);
             var classes = 'tb-calendar-day';
-            if (dateObj < startDate || dateObj > endDate || existing.indexOf(dateStr) !== -1) {
+            var inner = '<span class="tb-day-number">'+d+'</span>';
+            if (dateObj < startDate || dateObj > endDate) {
                 classes += ' tb-day-unavailable';
+            } else if (existingDates.indexOf(dateStr) !== -1) {
+                classes += ' tb-day-unavailable tb-day-has-availability';
+                inner += '<span class="tb-day-dots">...</span>';
             } else {
                 classes += ' tb-day-available';
                 if (selected.indexOf(dateStr) !== -1) {
                     classes += ' tb-selected';
                 }
             }
-            html += '<div class="' + classes + '" data-date="' + dateStr + '">' + d + '</div>';
+            html += '<div class="' + classes + '" data-date="' + dateStr + '">' + inner + '</div>';
         }
         html += '</div></div>';
         calendar.html(html);
@@ -80,11 +109,10 @@ jQuery(function($){
         var idx = selected.indexOf(date);
         if (idx > -1) {
             selected.splice(idx,1);
-            $(this).removeClass('tb-selected');
         } else {
             selected.push(date);
-            $(this).addClass('tb-selected');
         }
+        renderCalendar(current);
         refreshSelected();
     });
 
@@ -98,6 +126,52 @@ jQuery(function($){
         if ($(this).prop('disabled')) return;
         current.setMonth(current.getMonth() + 1);
         renderCalendar(current);
+    });
+
+    $('#tb-calendar').on('click', '.tb-day-dots', function(e){
+        e.stopPropagation();
+        $('#tb-day-menu').remove();
+        var date = $(this).closest('.tb-day-has-availability').data('date');
+        var offset = $(this).offset();
+        var menu = $('<div id="tb-day-menu" class="tb-day-menu"><button type="button" class="tb-day-info">Información</button><button type="button" class="tb-day-edit">Editar</button></div>');
+        menu.css({top: offset.top + $(this).height(), left: offset.left});
+        menu.data('date', date);
+        $('body').append(menu);
+    });
+
+    $('body').on('click', function(){ $('#tb-day-menu').remove(); });
+
+    $('body').on('click', '#tb-day-menu .tb-day-info', function(e){
+        e.stopPropagation();
+        var menu = $('#tb-day-menu');
+        var date = menu.data('date');
+        var slots = existingSlots[date] || [];
+        alert('Disponibilidad de ' + date + ':\n' + (slots.join('\n') || 'Sin tramos'));
+        menu.remove();
+    });
+
+    function loadSlots(slots) {
+        var container = $('#tb-time-slots').empty();
+        if (!slots.length) {
+            addSlot();
+        } else {
+            slots.forEach(function(s){
+                var parts = s.split('-');
+                addSlot(parts[0], parts[1]);
+            });
+        }
+    }
+
+    $('body').on('click', '#tb-day-menu .tb-day-edit', function(e){
+        e.stopPropagation();
+        var menu = $('#tb-day-menu');
+        var date = menu.data('date');
+        var slots = existingSlots[date] || [];
+        selected = [date];
+        loadSlots(slots);
+        renderCalendar(current);
+        refreshSelected();
+        menu.remove();
     });
 
     renderCalendar(current);

--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -172,19 +172,32 @@ class AdminController {
         if (!$tutor) {
             $messages[] = ['type' => 'error', 'text' => 'Tutor no encontrado.'];
             $existing_dates = [];
-            self::render_assign_availability($tutor, $messages, $existing_dates);
+            $existing_slots = [];
+            self::render_assign_availability($tutor, $messages, $existing_dates, $existing_slots);
             return;
         }
 
         if (isset($_POST['tb_assign_availability'])) {
-            $start = sanitize_text_field($_POST['tb_start_time'] ?? '');
-            $end   = sanitize_text_field($_POST['tb_end_time'] ?? '');
-            $dates = isset($_POST['tb_dates']) ? array_map('sanitize_text_field', (array)$_POST['tb_dates']) : [];
-            if ($start && $end && !empty($dates)) {
+            $starts = isset($_POST['tb_start_time']) ? array_map('sanitize_text_field', (array)$_POST['tb_start_time']) : [];
+            $ends   = isset($_POST['tb_end_time']) ? array_map('sanitize_text_field', (array)$_POST['tb_end_time']) : [];
+            $dates  = isset($_POST['tb_dates']) ? array_map('sanitize_text_field', (array)$_POST['tb_dates']) : [];
+
+            $slots = [];
+            foreach ($starts as $idx => $st) {
+                $en = $ends[$idx] ?? '';
+                if ($st && $en) {
+                    $slots[] = [$st, $en];
+                }
+            }
+
+            if (!empty($dates) && !empty($slots)) {
                 foreach ($dates as $date) {
-                    $start_dt = $date . 'T' . $start . ':00';
-                    $end_dt   = $date . 'T' . $end . ':00';
-                    CalendarService::create_calendar_event($tutor_id, 'DISPONIBLE', '', $start_dt, $end_dt);
+                    CalendarService::delete_available_events_by_date($tutor_id, $date);
+                    foreach ($slots as $slot) {
+                        $start_dt = $date . 'T' . $slot[0] . ':00';
+                        $end_dt   = $date . 'T' . $slot[1] . ':00';
+                        CalendarService::create_calendar_event($tutor_id, 'DISPONIBLE', '', $start_dt, $end_dt);
+                    }
                 }
                 $messages[] = ['type' => 'success', 'text' => 'Disponibilidad asignada correctamente.'];
             } else {
@@ -196,17 +209,21 @@ class AdminController {
         $end_range = date('Y-m-d', strtotime('+6 months'));
         $events = CalendarService::get_available_calendar_events($tutor_id, $start_range, $end_range);
         $existing_dates = [];
+        $existing_slots = [];
         foreach ($events as $ev) {
             if (isset($ev->start->dateTime)) {
-                $existing_dates[] = date('Y-m-d', strtotime($ev->start->dateTime));
+                $date = date('Y-m-d', strtotime($ev->start->dateTime));
+                $existing_dates[] = $date;
+                $existing_slots[$date][] = date('H:i', strtotime($ev->start->dateTime)) . '-' . date('H:i', strtotime($ev->end->dateTime));
             }
         }
         $existing_dates = array_values(array_unique($existing_dates));
+        $existing_slots = array_map('array_values', $existing_slots);
 
-        self::render_assign_availability($tutor, $messages, $existing_dates);
+        self::render_assign_availability($tutor, $messages, $existing_dates, $existing_slots);
     }
 
-    private static function render_assign_availability($tutor, $messages, $existing_dates) {
+    private static function render_assign_availability($tutor, $messages, $existing_dates, $existing_slots) {
         ?>
         <div class="tb-admin-wrapper">
             <?php foreach ($messages as $msg): ?>
@@ -218,10 +235,15 @@ class AdminController {
             <div class="tb-card">
                 <h2>Asignar Disponibilidad a <?php echo esc_html($tutor->nombre ?? ''); ?></h2>
                 <form method="POST">
-                    <label for="tb-start">Inicio</label>
-                    <input id="tb-start" type="time" name="tb_start_time" required>
-                    <label for="tb-end">Fin</label>
-                    <input id="tb-end" type="time" name="tb_end_time" required>
+                    <div id="tb-time-slots">
+                        <div class="tb-time-slot">
+                            <label>Inicio</label>
+                            <input type="time" name="tb_start_time[]" required>
+                            <label>Fin</label>
+                            <input type="time" name="tb_end_time[]" required>
+                            <button type="button" class="tb-button tb-add-slot">+</button>
+                        </div>
+                    </div>
                     <div id="tb-calendar"></div>
                     <ul id="tb-selected-dates"></ul>
                     <div id="tb-hidden-dates"></div>
@@ -231,112 +253,8 @@ class AdminController {
             </div>
         </div>
         <script>
-            var tbExistingAvailabilityDates = <?php echo wp_json_encode($existing_dates); ?>;
-            jQuery(function($){
-                if (!$('#tb-calendar').length) {
-                    return;
-                }
-
-                var existing = Array.isArray(window.tbExistingAvailabilityDates) ? window.tbExistingAvailabilityDates : [];
-                var selected = [];
-                var startDate = new Date();
-                startDate.setHours(0,0,0,0);
-                var endDate = new Date();
-                endDate.setMonth(endDate.getMonth() + 3);
-                endDate.setHours(0,0,0,0);
-                var current = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
-
-                function formatDate(d) {
-                    var month = '' + (d.getMonth() + 1);
-                    var day = '' + d.getDate();
-                    var year = d.getFullYear();
-                    if (month.length < 2) month = '0' + month;
-                    if (day.length < 2) day = '0' + day;
-                    return [year, month, day].join('-');
-                }
-
-                function refreshSelected() {
-                    var list = $('#tb-selected-dates').empty();
-                    var hidden = $('#tb-hidden-dates').empty();
-                    selected.sort();
-                    selected.forEach(function(d){
-                        list.append('<li>' + d + '</li>');
-                        hidden.append('<input type="hidden" name="tb_dates[]" value="' + d + '">');
-                    });
-                }
-
-                function renderCalendar(monthDate) {
-                    var calendar = $('#tb-calendar');
-                    var month = monthDate.getMonth();
-                    var year = monthDate.getFullYear();
-                    var monthNames = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
-                    var dayNames = ['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'];
-
-                    var html = '<div class="tb-calendar-month">';
-                    html += '<div class="tb-calendar-nav">';
-                    var prevDisabled = (monthDate.getFullYear() === startDate.getFullYear() && monthDate.getMonth() <= startDate.getMonth());
-                    var nextDisabled = (monthDate.getFullYear() === endDate.getFullYear() && monthDate.getMonth() >= endDate.getMonth());
-                    html += '<button id="tb_prev_month" class="tb-nav-btn"' + (prevDisabled ? ' disabled' : '') + '>&lt;</button>';
-                    html += '<span class="tb-calendar-month-name">' + monthNames[month] + ' ' + year + '</span>';
-                    html += '<button id="tb_next_month" class="tb-nav-btn"' + (nextDisabled ? ' disabled' : '') + '>&gt;</button>';
-                    html += '</div>';
-
-                    html += '<div class="tb-calendar-week-day-names">';
-                    dayNames.forEach(function(d){ html += '<div class="tb-calendar-week-day">' + d + '</div>'; });
-                    html += '</div>';
-
-                    html += '<div class="tb-calendar-days">';
-                    var firstDayIndex = new Date(year, month, 1).getDay();
-                    for (var i=0; i<firstDayIndex; i++) {
-                        html += '<div class="tb-calendar-day tb-empty"></div>';
-                    }
-                    var daysInMonth = new Date(year, month + 1, 0).getDate();
-                    for (var d=1; d<=daysInMonth; d++) {
-                        var dateObj = new Date(year, month, d);
-                        var dateStr = formatDate(dateObj);
-                        var classes = 'tb-calendar-day';
-                        if (dateObj < startDate || dateObj > endDate || existing.indexOf(dateStr) !== -1) {
-                            classes += ' tb-day-unavailable';
-                        } else {
-                            classes += ' tb-day-available';
-                            if (selected.indexOf(dateStr) !== -1) {
-                                classes += ' tb-selected';
-                            }
-                        }
-                        html += '<div class="' + classes + '" data-date="' + dateStr + '">' + d + '</div>';
-                    }
-                    html += '</div></div>';
-                    calendar.html(html);
-                }
-
-                $('#tb-calendar').on('click', '.tb-calendar-day.tb-day-available', function(){
-                    var date = $(this).data('date');
-                    var idx = selected.indexOf(date);
-                    if (idx > -1) {
-                        selected.splice(idx,1);
-                        $(this).removeClass('tb-selected');
-                    } else {
-                        selected.push(date);
-                        $(this).addClass('tb-selected');
-                    }
-                    refreshSelected();
-                });
-
-                $('#tb-calendar').on('click', '#tb_prev_month', function(){
-                    if ($(this).prop('disabled')) return;
-                    current.setMonth(current.getMonth() - 1);
-                    renderCalendar(current);
-                });
-
-                $('#tb-calendar').on('click', '#tb_next_month', function(){
-                    if ($(this).prop('disabled')) return;
-                    current.setMonth(current.getMonth() + 1);
-                    renderCalendar(current);
-                });
-
-                renderCalendar(current);
-                refreshSelected();
-            });
+            window.tbExistingAvailabilityDates = <?php echo wp_json_encode($existing_dates); ?>;
+            window.tbExistingAvailabilitySlots = <?php echo wp_json_encode($existing_slots); ?>;
         </script>
         <?php
     }

--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -92,6 +92,29 @@ class CalendarService {
     }
 
     /**
+     * Delete all availability events for a given tutor on a specific date.
+     */
+    public static function delete_available_events_by_date($tutor_id, $date) {
+        global $wpdb;
+        $tutor = $wpdb->get_row($wpdb->prepare("SELECT calendar_id FROM {$wpdb->prefix}tutores WHERE id=%d", $tutor_id));
+        if (!$tutor || empty($tutor->calendar_id)) { return 0; }
+        $service = self::get_calendar_service($tutor_id);
+        if (!$service) { return 0; }
+
+        $events = self::get_available_calendar_events($tutor_id, $date, $date);
+        $deleted = 0;
+        foreach ($events as $event) {
+            try {
+                $service->events->delete($tutor->calendar_id, $event->id);
+                $deleted++;
+            } catch (\Exception $e) {
+                // Ignore individual deletion errors
+            }
+        }
+        return $deleted;
+    }
+
+    /**
      * Delete all calendar events containing the provided DNI.
      */
     public static function delete_events_by_dni($dni) {


### PR DESCRIPTION
## Summary
- allow adding multiple time slots when assigning availability
- show context menu on days with existing availability for info and editing
- replace existing availability events when saving

## Testing
- `php -l includes/Admin/AdminController.php`
- `php -l includes/Google/CalendarService.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac1acd49a8832f93225b5f94a9b39c