### PR TITLE
Fix admin assets loading for availability form

### DIFF
--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -18,9 +18,11 @@ class AdminMenu {
     }
 
     public static function enqueue_assets($hook) {
-        if ($hook !== 'toplevel_page_tb-tutores') {
+        // Ensure assets are loaded on all plugin pages, even with additional actions.
+        if (strpos($hook, 'tb-tutores') === false) {
             return;
         }
+
         wp_enqueue_style('tb-admin', TB_PLUGIN_URL . 'assets/css/admin.css');
         if (isset($_GET['action']) && $_GET['action'] === 'tb_assign_availability') {
             wp_enqueue_style('tb-frontend', TB_PLUGIN_URL . 'assets/css/frontend.css');


### PR DESCRIPTION
## Summary
- ensure admin scripts and styles load on availability assignment page

## Testing
- `php -l includes/Admin/AdminMenu.php`
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68ac26712664832fbc87e2965829ba66