### PR TITLE
fix: ensure availability form scripts bind reliably

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -22,14 +22,19 @@ jQuery(function($){
         container.append(slot);
     }
 
-    $('#tb-time-slots').on('click', '.tb-add-slot', function(){
+    // Use delegated events to ensure handlers work even if the container
+    // is rendered dynamically after the script runs.
+    $(document).on('click', '#tb-time-slots .tb-add-slot', function(){
         addSlot();
     });
 
-    $('#tb-time-slots').on('click', '.tb-remove-slot', function(){
+    $(document).on('click', '#tb-time-slots .tb-remove-slot', function(){
         $(this).closest('.tb-time-slot').remove();
         if ($('#tb-time-slots .tb-add-slot').length === 0) {
-            $('#tb-time-slots .tb-time-slot').last().find('button').removeClass('tb-remove-slot').addClass('tb-add-slot').text('+');
+            $('#tb-time-slots .tb-time-slot').last().find('button')
+                .removeClass('tb-remove-slot')
+                .addClass('tb-add-slot')
+                .text('+');
         }
     });
 

--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -219,6 +219,14 @@ class AdminController {
         }
         $existing_dates = array_values(array_unique($existing_dates));
         $existing_slots = array_map('array_values', $existing_slots);
+        // Pass availability data to the admin script before it loads so that
+        // the calendar can render existing slots and dates correctly.
+        wp_add_inline_script(
+            'tb-admin',
+            'window.tbExistingAvailabilityDates = ' . wp_json_encode($existing_dates) . ';\n' .
+            'window.tbExistingAvailabilitySlots = ' . wp_json_encode($existing_slots) . ';',
+            'before'
+        );
 
         self::render_assign_availability($tutor, $messages, $existing_dates, $existing_slots);
     }
@@ -252,10 +260,6 @@ class AdminController {
                 </form>
             </div>
         </div>
-        <script>
-            window.tbExistingAvailabilityDates = <?php echo wp_json_encode($existing_dates); ?>;
-            window.tbExistingAvailabilitySlots = <?php echo wp_json_encode($existing_slots); ?>;
-        </script>
         <?php
     }
 


### PR DESCRIPTION
## Summary
- Use delegated jQuery events for dynamically inserted time slots
- Pass existing availability data before admin script loads

## Testing
- `php -l includes/Admin/AdminController.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac2e73d014832f82b6fb4d4a22c667