### PR TITLE
Permitir múltiples tramos de disponibilidad

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -109,3 +109,10 @@
     padding-left: 20px;
     list-style: disc;
 }
+
+.tb-time-range {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- agregar botón `+` para añadir nuevos pares de horario inicio/fin en la asignación de disponibilidad
- procesar varios tramos de horario al guardar la disponibilidad
- estilo flex para mostrar los tramos en línea

## Testing
- `php -l includes/Admin/AdminController.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5297b0d4832f8eef75cd05b2939d