### PR TITLE
Add view/edit menu for existing availability dates

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -125,6 +125,42 @@
   border-radius: 6px;
   cursor: pointer;
   user-select: none;
+  position: relative;
+}
+
+.tb-day-menu-btn {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+
+.tb-day-menu {
+  display: none;
+  position: absolute;
+  top: 20px;
+  right: 2px;
+  background: #fff;
+  border: 1px solid var(--tb-border-color);
+  border-radius: 4px;
+  z-index: 10;
+}
+
+.tb-day-menu button {
+  display: block;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 5px 10px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.tb-day-menu button:hover {
+  background: var(--tb-primary-color);
+  color: #fff;
 }
 
 .tb-calendar-day.tb-day-unavailable {

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -1,0 +1,29 @@
+<?php
+namespace TutoriasBooking\Admin;
+
+use TutoriasBooking\Google\CalendarService;
+
+class AjaxHandlers {
+    public static function init() {
+        add_action('wp_ajax_tb_get_day_availability', [self::class, 'ajax_get_day_availability']);
+    }
+
+    public static function ajax_get_day_availability() {
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permisos insuficientes.');
+        }
+        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $date = isset($_POST['date']) ? sanitize_text_field($_POST['date']) : '';
+        if (!$tutor_id || empty($date)) {
+            wp_send_json_error('Datos incompletos.');
+        }
+        $events = CalendarService::get_available_calendar_events($tutor_id, $date, $date);
+        $slots = [];
+        foreach ($events as $ev) {
+            if (isset($ev->start->dateTime) && isset($ev->end->dateTime)) {
+                $slots[] = date('H:i', strtotime($ev->start->dateTime)) . '-' . date('H:i', strtotime($ev->end->dateTime));
+            }
+        }
+        wp_send_json_success($slots);
+    }
+}

--- a/includes/Core/Loader.php
+++ b/includes/Core/Loader.php
@@ -6,12 +6,14 @@ class Loader {
         require_once TB_PLUGIN_DIR . 'includes/Admin/AdminMenu.php';
         require_once TB_PLUGIN_DIR . 'includes/Admin/AdminPage.php';
         require_once TB_PLUGIN_DIR . 'includes/Admin/AdminController.php';
+        require_once TB_PLUGIN_DIR . 'includes/Admin/AjaxHandlers.php';
         require_once TB_PLUGIN_DIR . 'includes/Frontend/Shortcodes.php';
         require_once TB_PLUGIN_DIR . 'includes/Frontend/AjaxHandlers.php';
         require_once TB_PLUGIN_DIR . 'includes/Google/GoogleClient.php';
         require_once TB_PLUGIN_DIR . 'includes/Google/CalendarService.php';
 
         \TutoriasBooking\Admin\AdminMenu::register();
+        \TutoriasBooking\Admin\AjaxHandlers::init();
         \TutoriasBooking\Frontend\AjaxHandlers::init();
     }
 }

--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -92,6 +92,28 @@ class CalendarService {
     }
 
     /**
+     * Delete all "DISPONIBLE" events for a specific date.
+     */
+    public static function delete_available_events_for_date($tutor_id, $date) {
+        global $wpdb;
+        $tutor = $wpdb->get_row($wpdb->prepare("SELECT calendar_id FROM {$wpdb->prefix}tutores WHERE id = %d", $tutor_id));
+        if (!$tutor || empty($tutor->calendar_id)) { return 0; }
+        $service = self::get_calendar_service($tutor_id);
+        if (!$service) { return 0; }
+        $events = self::get_available_calendar_events($tutor_id, $date, $date);
+        $deleted = 0;
+        foreach ($events as $event) {
+            try {
+                $service->events->delete($tutor->calendar_id, $event->id, ['sendUpdates' => 'all']);
+                $deleted++;
+            } catch (\Exception $e) {
+                // Ignore individual deletion errors
+            }
+        }
+        return $deleted;
+    }
+
+    /**
      * Delete all calendar events containing the provided DNI.
      */
     public static function delete_events_by_dni($dni) {


### PR DESCRIPTION
## Summary
- show dropdown on days with existing availability allowing view and edit
- enable editing of availability for a specific day with prefilled times
- add admin AJAX endpoint to fetch availability and delete helper

## Testing
- `php -l includes/Google/CalendarService.php`
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l includes/Core/Loader.php`
- `php -l includes/Admin/AdminController.php`


------
https://chatgpt.com/codex/tasks/task_e_68ad5a797db4832fb6be52ef0b1e2211