### PR TITLE
Validate availability ranges to prevent overlaps

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -212,4 +212,33 @@ jQuery(function($){
 
     renderCalendar(current);
     refreshSelected();
+
+    var $form = $('#tb-time-ranges').closest('form');
+    $form.on('submit', function(e){
+        var ranges = [];
+        var valid = true;
+        $('#tb-time-ranges .tb-time-range').each(function(){
+            var start = $(this).find('input[name="tb_start_time[]"]').val();
+            var end   = $(this).find('input[name="tb_end_time[]"]').val();
+            if (!start || !end) return;
+            if (start >= end) {
+                valid = false;
+                return false; // break
+            }
+            ranges.push({start:start, end:end});
+        });
+        if (valid) {
+            ranges.sort(function(a,b){ return a.start.localeCompare(b.start); });
+            for (var i=1; i<ranges.length; i++) {
+                if (ranges[i].start < ranges[i-1].end) {
+                    valid = false;
+                    break;
+                }
+            }
+        }
+        if (!valid) {
+            e.preventDefault();
+            alert('Los rangos de tiempo son inválidos o se solapan.');
+        }
+    });
 });

--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -188,30 +188,52 @@ class AdminController {
                 $dates = [$editing_date];
             }
             if (!empty($starts) && !empty($ends) && count($starts) === count($ends) && !empty($dates)) {
-                foreach ($dates as $date) {
-                    foreach ($starts as $idx => $start) {
-                        $end = $ends[$idx] ?? '';
-                        if (!$start || !$end) {
-                            continue;
+                $ranges = [];
+                $valid  = true;
+                foreach ($starts as $idx => $start) {
+                    $end = $ends[$idx] ?? '';
+                    if (!$start || !$end) {
+                        continue;
+                    }
+                    if ($start >= $end) {
+                        $valid = false;
+                        break;
+                    }
+                    $ranges[] = ['start' => $start, 'end' => $end];
+                }
+                if ($valid) {
+                    usort($ranges, function ($a, $b) {
+                        return strcmp($a['start'], $b['start']);
+                    });
+                    for ($i = 1; $i < count($ranges); $i++) {
+                        if ($ranges[$i]['start'] < $ranges[$i - 1]['end']) {
+                            $valid = false;
+                            break;
                         }
-
-                        $madridTz = new \DateTimeZone('Europe/Madrid');
-                        $utcTz    = new \DateTimeZone('UTC');
-
-                        $startObj = new \DateTime($date . 'T' . $start . ':00', $madridTz);
-                        $endObj   = new \DateTime($date . 'T' . $end   . ':00', $madridTz);
-
-                        $start_dt = $startObj->setTimezone($utcTz)->format('Y-m-d\TH:i:s');
-                        $end_dt   = $endObj->setTimezone($utcTz)->format('Y-m-d\TH:i:s');
-
-                        CalendarService::create_calendar_event($tutor_id, 'DISPONIBLE', '', $start_dt, $end_dt);
                     }
                 }
-                $messages[] = ['type' => 'success', 'text' => 'Disponibilidad asignada correctamente.'];
-                if ($editing_date) {
-                    $redirect = admin_url('admin.php?page=tb-tutores&action=tb_assign_availability&tutor_id=' . $tutor_id);
-                    wp_safe_redirect($redirect);
-                    exit;
+                if ($valid) {
+                    $madridTz = new \DateTimeZone('Europe/Madrid');
+                    $utcTz    = new \DateTimeZone('UTC');
+                    foreach ($dates as $date) {
+                        foreach ($ranges as $range) {
+                            $startObj = new \DateTime($date . 'T' . $range['start'] . ':00', $madridTz);
+                            $endObj   = new \DateTime($date . 'T' . $range['end']   . ':00', $madridTz);
+
+                            $start_dt = $startObj->setTimezone($utcTz)->format('Y-m-d\TH:i:s');
+                            $end_dt   = $endObj->setTimezone($utcTz)->format('Y-m-d\TH:i:s');
+
+                            CalendarService::create_calendar_event($tutor_id, 'DISPONIBLE', '', $start_dt, $end_dt);
+                        }
+                    }
+                    $messages[] = ['type' => 'success', 'text' => 'Disponibilidad asignada correctamente.'];
+                    if ($editing_date) {
+                        $redirect = admin_url('admin.php?page=tb-tutores&action=tb_assign_availability&tutor_id=' . $tutor_id);
+                        wp_safe_redirect($redirect);
+                        exit;
+                    }
+                } else {
+                    $messages[] = ['type' => 'error', 'text' => 'Los rangos de tiempo son inválidos o se solapan.'];
                 }
             } else {
                 $messages[] = ['type' => 'error', 'text' => 'Todos los campos son obligatorios.'];


### PR DESCRIPTION
## Summary
- add server-side validation rejecting invalid or overlapping time ranges when assigning availability
- provide client-side check for invalid or overlapping ranges with clear feedback

## Testing
- `php -l includes/Admin/AdminController.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b69866dfdc832f823aef6c7c625f38