### PR TITLE
Allow deleting availability for a day

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -7,14 +7,35 @@ jQuery(function($){
     $('#tb-time-ranges').on('click', '.tb-add-range', function(){
         var $clone = $(this).closest('.tb-time-range').clone();
         $clone.find('input').val('');
-        $clone.find('.tb-add-range').remove();
-        $clone.append('<button type="button" class="tb-button tb-remove-range">-</button>');
         $('#tb-time-ranges').append($clone);
+        updateRangeButtons();
     });
 
     $('#tb-time-ranges').on('click', '.tb-remove-range', function(){
         $(this).closest('.tb-time-range').remove();
+        updateRangeButtons();
     });
+
+    function updateRangeButtons(){
+        var $ranges = $('#tb-time-ranges .tb-time-range');
+        $ranges.find('.tb-add-range, .tb-remove-range').remove();
+        $ranges.each(function(idx){
+            if (window.tbEditingDate) {
+                if (idx === $ranges.length - 1) {
+                    $(this).append('<button type="button" class="tb-button tb-add-range">+</button>');
+                    $(this).append('<button type="button" class="tb-button tb-remove-range">-</button>');
+                } else {
+                    $(this).append('<button type="button" class="tb-button tb-remove-range">-</button>');
+                }
+            } else {
+                if (idx === 0) {
+                    $(this).append('<button type="button" class="tb-button tb-add-range">+</button>');
+                } else {
+                    $(this).append('<button type="button" class="tb-button tb-remove-range">-</button>');
+                }
+            }
+        });
+    }
 
     var existing = Array.isArray(window.tbExistingAvailabilityDates) ? window.tbExistingAvailabilityDates : [];
     var selected = [];
@@ -200,15 +221,11 @@ jQuery(function($){
             html += '<input type="time" name="tb_start_time[]" value="' + r.start + '" required>';
             html += '<label>Fin</label>';
             html += '<input type="time" name="tb_end_time[]" value="' + r.end + '" required>';
-            if (idx === window.tbEditingRanges.length - 1) {
-                html += '<button type="button" class="tb-button tb-add-range">+</button>';
-            } else {
-                html += '<button type="button" class="tb-button tb-remove-range">-</button>';
-            }
             html += '</div>';
             $('#tb-time-ranges').append(html);
         });
     }
+    updateRangeButtons();
 
     renderCalendar(current);
     refreshSelected();
@@ -239,6 +256,10 @@ jQuery(function($){
         if (!valid) {
             e.preventDefault();
             alert('Los rangos de tiempo son inválidos o se solapan.');
+        } else if (window.tbEditingDate && ranges.length === 0) {
+            if (!confirm('Se eliminará la disponibilidad existente para este día. ¿Desea continuar?')) {
+                e.preventDefault();
+            }
         }
     });
 });

--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -188,7 +188,13 @@ class AdminController {
                 $dates = [$editing_date];
                 $original_events = CalendarService::get_available_calendar_events($tutor_id, $editing_date, $editing_date);
             }
-            if (!empty($starts) && !empty($ends) && count($starts) === count($ends) && !empty($dates)) {
+            if ($editing_date && empty($starts) && empty($ends)) {
+                CalendarService::delete_available_events_for_date($tutor_id, $editing_date);
+                $messages[] = ['type' => 'success', 'text' => 'Disponibilidad eliminada correctamente.'];
+                $redirect = admin_url('admin.php?page=tb-tutores&action=tb_assign_availability&tutor_id=' . $tutor_id);
+                wp_safe_redirect($redirect);
+                exit;
+            } elseif (!empty($starts) && !empty($ends) && count($starts) === count($ends) && !empty($dates)) {
                 $today      = date('Y-m-d');
                 $date_valid = true;
                 foreach ($dates as $date) {


### PR DESCRIPTION
## Summary
- support clearing availability when editing a date with no time ranges
- adjust admin UI to submit without ranges and confirm full deletion

## Testing
- `php -l includes/Admin/AdminController.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68b6a1579410832f8145d0e76c1634f2