### PR TITLE
Improve calendar event creation error handling

### DIFF
--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -267,10 +267,16 @@ class AdminController {
                                 $end_dt   = $endObj->setTimezone($utcTz)->format('Y-m-d\\TH:i:s');
 
                                 $created = CalendarService::create_calendar_event($tutor_id, 'DISPONIBLE', '', $start_dt, $end_dt);
-                                if (!$created) {
+                                if (is_wp_error($created)) {
+                                    error_log('TutoriasBooking: handle_assign_availability - Error al crear evento: ' . $created->get_error_message());
+                                    $messages[] = [
+                                        'type' => 'error',
+                                        'text' => sprintf('Error al crear la disponibilidad para %s de %s a %s: %s', $date, $range['start'], $range['end'], $created->get_error_message())
+                                    ];
                                     $creation_failed = true;
                                     break 2;
                                 }
+                                error_log('TutoriasBooking: handle_assign_availability - Evento creado correctamente: ' . ($created->id ?? 'sin ID'));
                                 $any_created = true;
                             }
                         }
@@ -285,7 +291,12 @@ class AdminController {
                                         $end_dt   = (new \DateTime($ev->end->dateTime))->setTimezone($utcTz)->format('Y-m-d\\TH:i:s');
                                         $summary = $ev->summary ?? 'DISPONIBLE';
                                         $description = $ev->description ?? '';
-                                        CalendarService::create_calendar_event($tutor_id, $summary, $description, $start_dt, $end_dt);
+                                        $restored = CalendarService::create_calendar_event($tutor_id, $summary, $description, $start_dt, $end_dt);
+                                        if (is_wp_error($restored)) {
+                                            error_log('TutoriasBooking: handle_assign_availability - Error al restaurar evento: ' . $restored->get_error_message());
+                                        } else {
+                                            error_log('TutoriasBooking: handle_assign_availability - Evento restaurado: ' . ($restored->id ?? 'sin ID'));
+                                        }
                                     }
                                 }
                             }

--- a/includes/Frontend/AjaxHandlers.php
+++ b/includes/Frontend/AjaxHandlers.php
@@ -300,6 +300,12 @@ class AjaxHandlers {
         // Crear el evento en Google Calendar a través del CalendarService utilizando UTC
         $event = CalendarService::create_calendar_event($tutor_id, $summary, $description, $start_datetime_utc, $end_datetime_utc, $attendees);
 
+        if (is_wp_error($event)) {
+            error_log('TutoriasBooking: ajax_process_booking() - Error al crear evento de Google Calendar: ' . $event->get_error_message());
+            wp_send_json_error('Error al crear el evento de Google Calendar: ' . $event->get_error_message());
+            return;
+        }
+
         // Si el evento se creó con éxito en Google Calendar
         if ($event) {
             error_log('TutoriasBooking: ajax_process_booking() - Evento de Google Calendar creado con éxito. Event ID: ' . $event->id . ', Meet Link: ' . $event->hangoutLink);

--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -73,9 +73,13 @@ class CalendarService {
     public static function create_calendar_event($tutor_id, $summary, $description, $start_datetime, $end_datetime, $attendees=[]) {
         global $wpdb;
         $tutor = $wpdb->get_row($wpdb->prepare("SELECT calendar_id FROM {$wpdb->prefix}tutores WHERE id = %d", $tutor_id));
-        if (!$tutor || empty($tutor->calendar_id)) { return null; }
+        if (!$tutor || empty($tutor->calendar_id)) {
+            return new \WP_Error('missing_calendar_id', 'El tutor no tiene un calendar_id válido.');
+        }
         $service = self::get_calendar_service($tutor_id);
-        if (!$service) { return null; }
+        if (!$service) {
+            return new \WP_Error('service_unavailable', 'No se pudo obtener el servicio de Google Calendar.');
+        }
         $calendarId = $tutor->calendar_id;
         // $start_datetime and $end_datetime are expected to be in UTC
         $event = new \Google_Service_Calendar_Event([
@@ -97,7 +101,7 @@ class CalendarService {
                 ]
             );
         } catch (\Exception $e) {
-            return null;
+            return new \WP_Error('event_creation_failed', $e->getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
- return WP_Error details from CalendarService::create_calendar_event on failures
- log and report individual event creation results in handle_assign_availability
- surface calendar creation failures to frontend AJAX requests

## Testing
- `php -l includes/Google/CalendarService.php`
- `php -l includes/Admin/AdminController.php`
- `php -l includes/Frontend/AjaxHandlers.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6a5e79150832faee8c83af5a64ceb