### PR TITLE
Use shared TB_MAX_MONTHS for admin availability limit

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -45,7 +45,7 @@ jQuery(function($){
     var startDate = new Date();
     startDate.setHours(0,0,0,0);
     var endDate = new Date();
-    endDate.setMonth(endDate.getMonth() + 3);
+    endDate.setMonth(endDate.getMonth() + parseInt(tbAdminData.maxMonths, 10));
     endDate.setHours(0,0,0,0);
     var current = new Date(startDate.getFullYear(), startDate.getMonth(), 1);
 

--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -335,7 +335,7 @@ class AdminController {
         }
 
         $start_range = date('Y-m-d');
-        $end_range = date('Y-m-d', strtotime('+6 months'));
+        $end_range   = date('Y-m-d', strtotime('+' . TB_MAX_MONTHS . ' months'));
         $events = CalendarService::get_available_calendar_events($tutor_id, $start_range, $end_range);
         $existing_dates = [];
         $madridTz = new \DateTimeZone('Europe/Madrid');

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -52,7 +52,10 @@ class AdminMenu {
         wp_localize_script(
             'tb-admin',
             'tbAdminData',
-            ['ajax_nonce' => wp_create_nonce('tb_get_day_availability')]
+            [
+                'ajax_nonce' => wp_create_nonce('tb_get_day_availability'),
+                'maxMonths'  => TB_MAX_MONTHS,
+            ]
         );
     }
 }

--- a/tutorias-booking.php
+++ b/tutorias-booking.php
@@ -29,6 +29,10 @@ if ( ! defined( 'TB_PLUGIN_DIR' ) ) {
     define( 'TB_PLUGIN_DIR', plugin_dir_path( TB_PLUGIN_FILE ) );
 }
 
+if ( ! defined( 'TB_MAX_MONTHS' ) ) {
+    define( 'TB_MAX_MONTHS', 6 );
+}
+
 // Load environment variables from .env file if present
 $env_file = TB_PLUGIN_DIR . '.env';
 if (file_exists($env_file)) {


### PR DESCRIPTION
## Summary
- Define `TB_MAX_MONTHS` constant for shared max-months configuration
- Pass max-months to admin JS and use it for calendar end date
- Apply constant in availability queries for consistent range

## Testing
- `php -l tutorias-booking.php`
- `php -l includes/Admin/AdminMenu.php`
- `php -l includes/Admin/AdminController.php`
- `node --check assets/js/admin.js`

------
https://chatgpt.com/codex/tasks/task_e_68b6abd67fac832f964bdf32c4d2b21c