### PR TITLE
Validate availability ranges stay within same day

### DIFF
--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -257,7 +257,13 @@ class AdminController {
                         if (!$start || !$end) {
                             continue;
                         }
-                        if ($start >= $end) {
+                        $startTs = strtotime($start);
+                        $endTs   = strtotime($end);
+                        if ($startTs === false || $endTs === false) {
+                            $valid = false;
+                            break;
+                        }
+                        if ($endTs <= $startTs || ($endTs - $startTs) >= DAY_IN_SECONDS) {
                             $valid = false;
                             break;
                         }
@@ -376,7 +382,7 @@ class AdminController {
                             }
                         }
                     } else {
-                        $messages[] = ['type' => 'error', 'text' => 'Los rangos de tiempo son inválidos o se solapan.'];
+                        $messages[] = ['type' => 'error', 'text' => 'Los rangos de tiempo son inválidos o se solapan. Verifica que la hora final sea mayor que la inicial y que el rango no exceda las 24 horas.'];
                     }
                 } else {
                     $messages[] = ['type' => 'error', 'text' => 'No se pueden asignar fechas anteriores a hoy.'];


### PR DESCRIPTION
## Summary
- ensure assigned availability end time is after start time and under 24h
- clarify error message for invalid or overlapping ranges

## Testing
- `php -l includes/Admin/AdminController.php`
- `composer validate --no-interaction`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1525c88832fbc7245a877d7cae0