### PR TITLE
Allow availability creation with internal appointments

### DIFF
--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -362,8 +362,11 @@ class AdminController {
                                         $busyEnd   = new \DateTime($ev->end->dateTime);
                                         $busyEnd->setTimezone($madridTz);
                                         if ($busyStart < $endObj && $busyEnd > $startObj) {
-                                            $overlap = true;
-                                            break;
+                                            // Allow busy events entirely within the availability range
+                                            if (!($busyStart >= $startObj && $busyEnd <= $endObj)) {
+                                                $overlap = true;
+                                                break;
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary
- ignore busy events fully contained within a new availability range to prevent false overlap errors

## Testing
- `php -l includes/Admin/AdminController.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6cd6dc954832fbaa5b3d82540f7cc