### PR TITLE
Add appointment editing with Google Calendar integration

### DIFF
--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -63,6 +63,7 @@ class AdminMenu {
             'tbAdminData',
             [
                 'ajax_nonce' => wp_create_nonce('tb_get_day_availability'),
+                'edit_nonce' => wp_create_nonce('tb_edit_appointment'),
                 'maxMonths'  => TB_MAX_MONTHS,
             ]
         );

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -2,10 +2,12 @@
 namespace TutoriasBooking\Admin;
 
 use TutoriasBooking\Google\CalendarService;
+use TutoriasBooking\Admin\AppointmentsController;
 
 class AjaxHandlers {
     public static function init() {
         add_action('wp_ajax_tb_get_day_availability', [self::class, 'ajax_get_day_availability']);
+        add_action('wp_ajax_tb_edit_appointment', [self::class, 'ajax_edit_appointment']);
     }
 
     public static function ajax_get_day_availability() {
@@ -31,5 +33,18 @@ class AjaxHandlers {
             }
         }
         wp_send_json_success($slots);
+    }
+
+    public static function ajax_edit_appointment() {
+        check_ajax_referer('tb_edit_appointment', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permisos insuficientes.');
+        }
+
+        $result = AppointmentsController::handle_edit();
+        if (is_wp_error($result)) {
+            wp_send_json_error($result->get_error_message());
+        }
+        wp_send_json_success($result);
     }
 }

--- a/includes/Admin/AppointmentsController.php
+++ b/includes/Admin/AppointmentsController.php
@@ -2,6 +2,8 @@
 namespace TutoriasBooking\Admin;
 
 use WP_List_Table;
+use TutoriasBooking\Google\CalendarService;
+use WP_Error;
 
 class AppointmentsController {
     public static function render_page() {
@@ -13,6 +15,94 @@ class AppointmentsController {
         $appointments_table->prepare_items();
 
         include TB_PLUGIN_DIR . 'templates/admin/appointments-page.php';
+    }
+
+    /**
+     * Handle the editing of an appointment.
+     *
+     * Expects POST fields: appointment_id, event_id, new_start, new_end, tutor_id
+     * new_start and new_end are expected in 'Y-m-d\TH:i' (local timezone).
+     *
+     * @return array|WP_Error
+     */
+    public static function handle_edit() {
+        if ( $_SERVER['REQUEST_METHOD'] !== 'POST' ) {
+            return new WP_Error( 'invalid_method', 'Invalid request method.' );
+        }
+
+        $appointment_id = isset( $_POST['appointment_id'] ) ? intval( $_POST['appointment_id'] ) : 0;
+        $event_id       = isset( $_POST['event_id'] ) ? sanitize_text_field( $_POST['event_id'] ) : '';
+        $new_start      = isset( $_POST['new_start'] ) ? sanitize_text_field( $_POST['new_start'] ) : '';
+        $new_end        = isset( $_POST['new_end'] ) ? sanitize_text_field( $_POST['new_end'] ) : '';
+        $tutor_id       = isset( $_POST['tutor_id'] ) ? intval( $_POST['tutor_id'] ) : 0;
+
+        if ( ! $appointment_id || empty( $event_id ) || empty( $new_start ) || empty( $new_end ) || ! $tutor_id ) {
+            return new WP_Error( 'missing_fields', 'Datos incompletos.' );
+        }
+
+        global $wpdb;
+
+        $tutor = $wpdb->get_row( $wpdb->prepare( "SELECT email, calendar_id, nombre FROM {$wpdb->prefix}tutores WHERE id = %d", $tutor_id ) );
+        if ( ! $tutor ) {
+            return new WP_Error( 'invalid_tutor', 'Tutor no válido.' );
+        }
+
+        $appointment = $wpdb->get_row( $wpdb->prepare( "SELECT alumno_id FROM {$wpdb->prefix}tb_citas WHERE ID = %d", $appointment_id ) );
+        if ( ! $appointment ) {
+            return new WP_Error( 'invalid_appointment', 'Cita no válida.' );
+        }
+
+        $student = $wpdb->get_row( $wpdb->prepare( "SELECT email, nombre, apellido FROM {$wpdb->prefix}alumnos_reserva WHERE id = %d", $appointment->alumno_id ) );
+
+        // Convert provided times from local Europe/Madrid to UTC
+        $madrid_tz = new \DateTimeZone( 'Europe/Madrid' );
+        $utc_tz    = new \DateTimeZone( 'UTC' );
+        $start_dt  = new \DateTime( $new_start, $madrid_tz );
+        $end_dt    = new \DateTime( $new_end, $madrid_tz );
+        $start_dt->setTimezone( $utc_tz );
+        $end_dt->setTimezone( $utc_tz );
+
+        $updated_event = CalendarService::update_event( $event_id, $start_dt->format( 'c' ), $end_dt->format( 'c' ), $tutor->calendar_id );
+        if ( is_wp_error( $updated_event ) ) {
+            return $updated_event;
+        }
+
+        $wpdb->update(
+            $wpdb->prefix . 'tb_citas',
+            [
+                'start'      => $new_start,
+                'end'        => $new_end,
+                'tutor_id'   => $tutor_id,
+                'updated_at' => current_time( 'mysql' ),
+            ],
+            [ 'ID' => $appointment_id ],
+            [ '%s', '%s', '%d', '%s' ],
+            [ '%d' ]
+        );
+
+        if ( $student ) {
+            $student_subject = 'Cita de tutoría actualizada';
+            $student_message = sprintf(
+                "Hola %s %s,\n\nTu cita ha sido actualizada.\nNueva fecha y hora: %s - %s\nTutor: %s\n",
+                $student->nombre,
+                $student->apellido,
+                $new_start,
+                $new_end,
+                $tutor->nombre
+            );
+            wp_mail( $student->email, $student_subject, $student_message );
+        }
+
+        $tutor_subject = 'Cita de tutoría actualizada';
+        $tutor_message = sprintf(
+            "Se ha actualizado una cita.\nFecha y hora: %s - %s\nAlumno ID: %d",
+            $new_start,
+            $new_end,
+            $appointment->alumno_id
+        );
+        wp_mail( $tutor->email, $tutor_subject, $tutor_message );
+
+        return [ 'success' => true ];
     }
 }
 
@@ -28,7 +118,7 @@ class Appointments_List_Table extends WP_List_Table {
     public static function get_appointments( $per_page = 20, $page_number = 1 ) {
         global $wpdb;
         $table = $wpdb->prefix . 'tb_citas';
-        $sql   = "SELECT ID, tutor_id, alumno_id, inicio, fin, estado FROM $table";
+        $sql   = "SELECT ID, tutor_id, alumno_id, inicio, fin, estado, event_id FROM $table";
 
         $orderby = ! empty( $_REQUEST['orderby'] ) ? esc_sql( $_REQUEST['orderby'] ) : 'ID';
         $order   = ! empty( $_REQUEST['order'] ) ? esc_sql( $_REQUEST['order'] ) : 'asc';
@@ -70,6 +160,7 @@ class Appointments_List_Table extends WP_List_Table {
             'inicio'    => 'Inicio',
             'fin'       => 'Fin',
             'estado'    => 'Estado',
+            'actions'   => 'Acciones',
         ];
     }
 
@@ -84,5 +175,17 @@ class Appointments_List_Table extends WP_List_Table {
 
     public function column_default( $item, $column_name ) {
         return $item[ $column_name ];
+    }
+
+    public function column_actions( $item ) {
+        $button = sprintf(
+            '<button type="button" class="button tb-edit-appointment" data-id="%d" data-event="%s" data-start="%s" data-end="%s" data-tutor="%d">Editar</button>',
+            intval( $item['ID'] ),
+            esc_attr( $item['event_id'] ?? '' ),
+            esc_attr( $item['inicio'] ),
+            esc_attr( $item['fin'] ),
+            intval( $item['tutor_id'] )
+        );
+        return $button;
     }
 }

--- a/templates/admin/appointments-page.php
+++ b/templates/admin/appointments-page.php
@@ -8,3 +8,74 @@
         <?php $appointments_table->display(); ?>
     </form>
 </div>
+
+<?php
+global $wpdb;
+$tutors = $wpdb->get_results( "SELECT id, nombre FROM {$wpdb->prefix}tutores" );
+?>
+<div id="tb-edit-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.5);">
+    <div style="background:#fff; padding:20px; max-width:400px; margin:50px auto;">
+        <form id="tb-edit-form">
+            <input type="hidden" id="tb-edit-id" name="appointment_id" />
+            <input type="hidden" id="tb-edit-event" name="event_id" />
+            <p>
+                <label>Inicio<br/>
+                    <input type="datetime-local" id="tb-edit-start" name="new_start" />
+                </label>
+            </p>
+            <p>
+                <label>Fin<br/>
+                    <input type="datetime-local" id="tb-edit-end" name="new_end" />
+                </label>
+            </p>
+            <p>
+                <label>Tutor<br/>
+                    <select id="tb-edit-tutor" name="tutor_id">
+                        <?php foreach ( $tutors as $t ) : ?>
+                            <option value="<?php echo esc_attr( $t->id ); ?>"><?php echo esc_html( $t->nombre ); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </label>
+            </p>
+            <p>
+                <button type="submit" class="button button-primary">Guardar</button>
+                <button type="button" class="button" id="tb-edit-cancel">Cancelar</button>
+            </p>
+        </form>
+    </div>
+</div>
+
+<script>
+jQuery(function($){
+    $('.tb-edit-appointment').on('click', function(){
+        $('#tb-edit-id').val($(this).data('id'));
+        $('#tb-edit-event').val($(this).data('event'));
+        $('#tb-edit-start').val($(this).data('start'));
+        $('#tb-edit-end').val($(this).data('end'));
+        $('#tb-edit-tutor').val($(this).data('tutor'));
+        $('#tb-edit-modal').show();
+    });
+    $('#tb-edit-cancel').on('click', function(){
+        $('#tb-edit-modal').hide();
+    });
+    $('#tb-edit-form').on('submit', function(e){
+        e.preventDefault();
+        var data = {
+            action: 'tb_edit_appointment',
+            nonce: tbAdminData.edit_nonce,
+            appointment_id: $('#tb-edit-id').val(),
+            event_id: $('#tb-edit-event').val(),
+            new_start: $('#tb-edit-start').val(),
+            new_end: $('#tb-edit-end').val(),
+            tutor_id: $('#tb-edit-tutor').val()
+        };
+        $.post(ajaxurl, data, function(res){
+            if(res.success){
+                location.reload();
+            } else {
+                alert(res.data || 'Error al editar la cita');
+            }
+        });
+    });
+});
+</script>


### PR DESCRIPTION
## Summary
- allow editing appointments via new admin modal and AJAX endpoint
- update Google Calendar and database when appointments are edited
- email tutor and student with updated details

## Testing
- `php -l includes/Admin/AppointmentsController.php`
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l includes/Admin/AdminMenu.php`
- `php -l includes/Google/CalendarService.php`
- `php -l templates/admin/appointments-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6dab9c49c832faa4965f4486e3579