### PR TITLE
Add appointment attachment management

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -279,3 +279,51 @@ jQuery(function($){
         });
     });
 });
+
+jQuery(function($){
+    var $inputs = $('.tb-attachment-input');
+    if (!$inputs.length) {
+        return;
+    }
+
+    $inputs.on('change', function(){
+        var file = this.files[0];
+        if (!file) return;
+        var citaId = $(this).data('cita');
+        var formData = new FormData();
+        formData.append('action', 'tb_upload_attachment');
+        formData.append('nonce', tbAdminData.upload_nonce);
+        formData.append('cita_id', citaId);
+        formData.append('attachment', file);
+        $.ajax({
+            url: ajaxurl,
+            type: 'POST',
+            data: formData,
+            contentType: false,
+            processData: false,
+            success: function(res){
+                if(res.success){
+                    location.reload();
+                } else {
+                    alert(res.data || 'Error al subir adjunto');
+                }
+            }
+        });
+    });
+
+    $('.tb-attachments').on('click', '.tb-delete-attachment', function(){
+        if(!confirm('¿Eliminar adjunto?')) return;
+        var id = $(this).data('id');
+        $.post(ajaxurl, {
+            action: 'tb_delete_attachment',
+            nonce: tbAdminData.delete_nonce,
+            attachment_id: id
+        }, function(res){
+            if(res.success){
+                location.reload();
+            } else {
+                alert(res.data || 'Error al eliminar adjunto');
+            }
+        });
+    });
+});

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -64,6 +64,8 @@ class AdminMenu {
             [
                 'ajax_nonce' => wp_create_nonce('tb_get_day_availability'),
                 'edit_nonce' => wp_create_nonce('tb_edit_appointment'),
+                'upload_nonce' => wp_create_nonce('tb_upload_attachment'),
+                'delete_nonce' => wp_create_nonce('tb_delete_attachment'),
                 'maxMonths'  => TB_MAX_MONTHS,
             ]
         );

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -8,6 +8,8 @@ class AjaxHandlers {
     public static function init() {
         add_action('wp_ajax_tb_get_day_availability', [self::class, 'ajax_get_day_availability']);
         add_action('wp_ajax_tb_edit_appointment', [self::class, 'ajax_edit_appointment']);
+        add_action('wp_ajax_tb_upload_attachment', [self::class, 'ajax_upload_attachment']);
+        add_action('wp_ajax_tb_delete_attachment', [self::class, 'ajax_delete_attachment']);
     }
 
     public static function ajax_get_day_availability() {
@@ -46,5 +48,68 @@ class AjaxHandlers {
             wp_send_json_error($result->get_error_message());
         }
         wp_send_json_success($result);
+    }
+
+    public static function ajax_upload_attachment() {
+        check_ajax_referer('tb_upload_attachment', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permisos insuficientes.');
+        }
+
+        if (empty($_FILES['attachment']) || empty($_POST['cita_id'])) {
+            wp_send_json_error('Datos incompletos.');
+        }
+
+        $file = $_FILES['attachment'];
+        $allowed = ['image/jpeg', 'image/png', 'application/pdf'];
+        if (!in_array($file['type'], $allowed, true)) {
+            wp_send_json_error('Tipo de archivo no permitido.');
+        }
+
+        $uploaded = wp_handle_upload($file, ['test_form' => false]);
+        if (isset($uploaded['error'])) {
+            wp_send_json_error($uploaded['error']);
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'tb_cita_adjuntos';
+        $wpdb->insert(
+            $table,
+            [
+                'cita_id'    => intval($_POST['cita_id']),
+                'file_url'   => esc_url_raw($uploaded['url']),
+                'uploaded_by'=> get_current_user_id(),
+                'uploaded_at'=> current_time('mysql'),
+            ],
+            ['%d', '%s', '%d', '%s']
+        );
+
+        wp_send_json_success(['url' => $uploaded['url']]);
+    }
+
+    public static function ajax_delete_attachment() {
+        check_ajax_referer('tb_delete_attachment', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permisos insuficientes.');
+        }
+
+        $attachment_id = isset($_POST['attachment_id']) ? intval($_POST['attachment_id']) : 0;
+        if (!$attachment_id) {
+            wp_send_json_error('ID inválido.');
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'tb_cita_adjuntos';
+        $attachment = $wpdb->get_row($wpdb->prepare("SELECT file_url FROM {$table} WHERE id = %d", $attachment_id));
+        if ($attachment) {
+            $uploads = wp_upload_dir();
+            $file_path = str_replace($uploads['baseurl'], $uploads['basedir'], $attachment->file_url);
+            if (file_exists($file_path)) {
+                @unlink($file_path);
+            }
+            $wpdb->delete($table, ['id' => $attachment_id], ['%d']);
+        }
+
+        wp_send_json_success();
     }
 }

--- a/includes/Admin/AppointmentsController.php
+++ b/includes/Admin/AppointmentsController.php
@@ -158,9 +158,10 @@ class Appointments_List_Table extends WP_List_Table {
             'tutor_id'  => 'Tutor',
             'alumno_id' => 'Alumno',
             'inicio'    => 'Inicio',
-            'fin'       => 'Fin',
-            'estado'    => 'Estado',
-            'actions'   => 'Acciones',
+            'fin'         => 'Fin',
+            'estado'      => 'Estado',
+            'attachments' => 'Adjuntos',
+            'actions'     => 'Acciones',
         ];
     }
 
@@ -187,5 +188,25 @@ class Appointments_List_Table extends WP_List_Table {
             intval( $item['tutor_id'] )
         );
         return $button;
+    }
+
+    public function column_attachments( $item ) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'tb_cita_adjuntos';
+        $attachments = $wpdb->get_results( $wpdb->prepare( "SELECT id, file_url FROM {$table} WHERE cita_id = %d", $item['ID'] ) );
+        $html = '<div class="tb-attachments">';
+        if ( $attachments ) {
+            foreach ( $attachments as $att ) {
+                $html .= sprintf(
+                    '<div><a href="%1$s" target="_blank">%2$s</a> <button type="button" class="tb-delete-attachment" data-id="%3$d">Eliminar</button></div>',
+                    esc_url( $att->file_url ),
+                    esc_html( basename( $att->file_url ) ),
+                    intval( $att->id )
+                );
+            }
+        }
+        $html .= sprintf( '<input type="file" class="tb-attachment-input" data-cita="%d" />', intval( $item['ID'] ) );
+        $html .= '</div>';
+        return $html;
     }
 }

--- a/includes/Core/Activator.php
+++ b/includes/Core/Activator.php
@@ -37,5 +37,16 @@ class Activator {
             UNIQUE KEY unique_dni (dni)
         ) {$charset_collate};";
         dbDelta($sql_reserva);
+
+        $sql_adjuntos = "CREATE TABLE {$wpdb->prefix}tb_cita_adjuntos (
+            id INT AUTO_INCREMENT,
+            cita_id INT NOT NULL,
+            file_url TEXT NOT NULL,
+            uploaded_by BIGINT(20) UNSIGNED NOT NULL,
+            uploaded_at DATETIME NOT NULL,
+            PRIMARY KEY (id),
+            KEY cita_id (cita_id)
+        ) {$charset_collate};";
+        dbDelta($sql_adjuntos);
     }
 }

--- a/templates/admin/appointments-page.php
+++ b/templates/admin/appointments-page.php
@@ -4,7 +4,7 @@
 <div class="tb-admin-wrapper">
     <h1 class="tb-title">Gestión de Citas</h1>
     <input type="text" id="tb-appointments-filter" placeholder="Filtrar citas..." />
-    <form method="post">
+    <form method="post" enctype="multipart/form-data">
         <?php $appointments_table->display(); ?>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- create `tb_cita_adjuntos` table for storing appointment attachments
- allow admins to upload or remove files from appointments
- add dynamic JS handlers for attachment upload and deletion

## Testing
- `php -l includes/Core/Activator.php`
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l includes/Admin/AdminMenu.php`
- `php -l includes/Admin/AppointmentsController.php`
- `php -l templates/admin/appointments-page.php`
- `node --check assets/js/admin.js`

------
https://chatgpt.com/codex/tasks/task_e_68b6dc2ed794832f8e8ae28287b7c116