### PR TITLE
Add appointment management service

### DIFF
--- a/includes/Core/Activator.php
+++ b/includes/Core/Activator.php
@@ -37,5 +37,37 @@ class Activator {
             UNIQUE KEY unique_dni (dni)
         ) {$charset_collate};";
         dbDelta($sql_reserva);
+
+        // Tabla principal de citas
+        $sql_citas = "CREATE TABLE {$wpdb->prefix}tb_citas (
+            id INT AUTO_INCREMENT,
+            alumno_id INT NOT NULL,
+            tutor_id INT NOT NULL,
+            event_id VARCHAR(255),
+            participant_name VARCHAR(200),
+            participant_email VARCHAR(100),
+            description TEXT,
+            location VARCHAR(255),
+            start_datetime DATETIME NOT NULL,
+            end_datetime DATETIME NOT NULL,
+            estado VARCHAR(50) DEFAULT 'confirmada',
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id)
+        ) {$charset_collate};";
+        dbDelta($sql_citas);
+
+        // Historial de modificaciones de citas
+        $sql_historial = "CREATE TABLE {$wpdb->prefix}tb_citas_historial (
+            id INT AUTO_INCREMENT,
+            cita_id INT NOT NULL,
+            usuario INT,
+            accion VARCHAR(50),
+            datos LONGTEXT,
+            fecha DATETIME DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            KEY cita_id (cita_id)
+        ) {$charset_collate};";
+        dbDelta($sql_historial);
     }
 }

--- a/includes/Core/AppointmentService.php
+++ b/includes/Core/AppointmentService.php
@@ -1,0 +1,160 @@
+<?php
+namespace TutoriasBooking\Core;
+
+use TutoriasBooking\Google\CalendarService;
+
+/**
+ * Servicio para gestionar citas.
+ * Incluye listados con filtros, edición y reprogramación.
+ */
+class AppointmentService {
+    /**
+     * Obtener lista de citas con filtros opcionales.
+     *
+     * @param array $args ['tutor_id'=>int,'from'=>string,'to'=>string,'estado'=>string]
+     * @return array
+     */
+    public static function list($args = []) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'tb_citas';
+        $where  = '1=1';
+        $params = [];
+        if (!empty($args['tutor_id'])) {
+            $where .= ' AND tutor_id = %d';
+            $params[] = intval($args['tutor_id']);
+        }
+        if (!empty($args['from'])) {
+            $where .= ' AND start_datetime >= %s';
+            $params[] = $args['from'];
+        }
+        if (!empty($args['to'])) {
+            $where .= ' AND start_datetime <= %s';
+            $params[] = $args['to'];
+        }
+        if (!empty($args['estado'])) {
+            $where .= ' AND estado = %s';
+            $params[] = $args['estado'];
+        }
+        $sql = $wpdb->prepare("SELECT * FROM {$table} WHERE {$where} ORDER BY start_datetime ASC", $params);
+        return $wpdb->get_results($sql);
+    }
+
+    /**
+     * Actualizar campos no relacionados con el horario.
+     *
+     * @param int   $id   ID de la cita
+     * @param array $data ['participant_name'=>string,'description'=>string]
+     * @return bool
+     */
+    public static function update_details($id, $data) {
+        if (!current_user_can('edit_posts')) {
+            return false;
+        }
+        global $wpdb;
+        $table  = $wpdb->prefix . 'tb_citas';
+        $fields = [];
+        $format = [];
+        if (isset($data['participant_name'])) {
+            $fields['participant_name'] = sanitize_text_field($data['participant_name']);
+            $format[] = '%s';
+        }
+        if (isset($data['description'])) {
+            $fields['description'] = sanitize_textarea_field($data['description']);
+            $format[] = '%s';
+        }
+        if (empty($fields)) {
+            return false;
+        }
+        $fields['updated_at'] = current_time('mysql');
+        $format[] = '%s';
+        $updated = $wpdb->update($table, $fields, ['id' => intval($id)], $format, ['%d']);
+        if ($updated !== false) {
+            self::log_history($id, 'editar', $fields);
+        }
+        return $updated !== false;
+    }
+
+    /**
+     * Reprogramar una cita.
+     *
+     * @param int    $id        ID de la cita
+     * @param string $new_start Fecha y hora inicio (UTC) Y-m-d H:i:s
+     * @param string $new_end   Fecha y hora fin (UTC)
+     * @param array  $args      Campos extra ['location'=>string]
+     * @return true|\WP_Error
+     */
+    public static function reschedule($id, $new_start, $new_end, $args = []) {
+        if (!current_user_can('edit_posts')) {
+            return new \WP_Error('forbidden', 'Permisos insuficientes');
+        }
+        global $wpdb;
+        $table = $wpdb->prefix . 'tb_citas';
+        $cita  = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$table} WHERE id = %d", intval($id)));
+        if (!$cita) {
+            return new \WP_Error('not_found', 'Cita no encontrada');
+        }
+        $date = gmdate('Y-m-d', strtotime($new_start));
+        $busy = CalendarService::get_busy_calendar_events($cita->tutor_id, $date, $date);
+        $new_start_ts = strtotime($new_start);
+        $new_end_ts   = strtotime($new_end);
+        foreach ($busy as $ev) {
+            if ($ev->id === $cita->event_id) {
+                continue;
+            }
+            $ev_start = strtotime($ev->start->dateTime);
+            $ev_end   = strtotime($ev->end->dateTime);
+            if ($ev_start < $new_end_ts && $ev_end > $new_start_ts) {
+                return new \WP_Error('overlap', 'La nueva franja se solapa con otra cita.');
+            }
+        }
+        $changes = [
+            'start' => $new_start,
+            'end'   => $new_end,
+        ];
+        if (isset($args['location'])) {
+            $changes['location'] = sanitize_text_field($args['location']);
+        }
+        $event = CalendarService::update_calendar_event($cita->tutor_id, $cita->event_id, $changes);
+        if (is_wp_error($event)) {
+            return $event;
+        }
+        $fields = [
+            'start_datetime' => $new_start,
+            'end_datetime'   => $new_end,
+            'updated_at'     => current_time('mysql'),
+        ];
+        if (isset($changes['location'])) {
+            $fields['location'] = $changes['location'];
+        }
+        $wpdb->update($table, $fields, ['id' => $id], array_fill(0, count($fields), '%s'), ['%d']);
+        self::log_history($id, 'reprogramar', $fields);
+        // Notificar a las partes
+        $subject = 'Cita reprogramada';
+        $message = 'Tu cita ha sido reprogramada para el ' . $new_start;
+        wp_mail($cita->participant_email, $subject, $message);
+        $tutor = $wpdb->get_row($wpdb->prepare("SELECT email FROM {$wpdb->prefix}tutores WHERE id = %d", $cita->tutor_id));
+        if ($tutor) {
+            wp_mail($tutor->email, $subject, $message);
+        }
+        return true;
+    }
+
+    /**
+     * Guardar entrada de historial.
+     */
+    private static function log_history($cita_id, $accion, $data) {
+        global $wpdb;
+        $table = $wpdb->prefix . 'tb_citas_historial';
+        $wpdb->insert(
+            $table,
+            [
+                'cita_id' => intval($cita_id),
+                'usuario' => get_current_user_id(),
+                'accion'  => $accion,
+                'datos'   => maybe_serialize($data),
+                'fecha'   => current_time('mysql'),
+            ],
+            ['%d', '%d', '%s', '%s', '%s']
+        );
+    }
+}

--- a/includes/Core/Loader.php
+++ b/includes/Core/Loader.php
@@ -11,6 +11,7 @@ class Loader {
         require_once TB_PLUGIN_DIR . 'includes/Frontend/AjaxHandlers.php';
         require_once TB_PLUGIN_DIR . 'includes/Google/GoogleClient.php';
         require_once TB_PLUGIN_DIR . 'includes/Google/CalendarService.php';
+        require_once TB_PLUGIN_DIR . 'includes/Core/AppointmentService.php';
 
         \TutoriasBooking\Admin\AdminMenu::register();
         \TutoriasBooking\Admin\AjaxHandlers::init();

--- a/includes/Frontend/AjaxHandlers.php
+++ b/includes/Frontend/AjaxHandlers.php
@@ -343,6 +343,28 @@ class AjaxHandlers {
                 $reservation_id = $wpdb->insert_id;
             }
             error_log('TutoriasBooking: ajax_process_booking() - Registro actualizado. ID: ' . $reservation_id);
+
+            // Guardar la cita en la tabla propia
+            $citas_table = $wpdb->prefix . 'tb_citas';
+            $wpdb->insert(
+                $citas_table,
+                [
+                    'alumno_id'        => $reservation_id,
+                    'tutor_id'         => $tutor_id,
+                    'event_id'         => $event->id,
+                    'participant_name' => $nombreAlumno . ' ' . $apellidoAlumno,
+                    'participant_email'=> $email,
+                    'description'      => $description,
+                    'location'         => $event->hangoutLink,
+                    'start_datetime'   => $start_datetime_utc,
+                    'end_datetime'     => $end_datetime_utc,
+                    'estado'           => 'confirmada',
+                    'created_at'       => current_time('mysql'),
+                    'updated_at'       => current_time('mysql'),
+                ],
+                ['%d','%d','%s','%s','%s','%s','%s','%s','%s','%s','%s','%s']
+            );
+
             // Calcular el día de la semana de la fecha del examen
             $day_of_week = date_i18n('l', strtotime($exam_date));
 


### PR DESCRIPTION
## Summary
- store appointments and adjustment history in new database tables
- add AppointmentService for listing, editing, and rescheduling with conflict checks
- support updating Google Calendar events and persisting bookings in custom table

## Testing
- `php -l includes/Core/Activator.php`
- `php -l includes/Core/AppointmentService.php`
- `php -l includes/Core/Loader.php`
- `php -l includes/Google/CalendarService.php`
- `php -l includes/Frontend/AjaxHandlers.php`
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68b6e121e280832fbb15da2eb7a92f31