### PR TITLE
Manage appointments directly via Google Calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Este proyecto es un plugin de WordPress para gestionar la reserva de tutorías d
 - Creación automática de eventos en Google Calendar con enlace de Google Meet.
 - Notificaciones por correo electrónico a los asistentes.
 - Panel de administración para gestionar tutores y tokens de autenticación.
-- Almacenamiento de reservas, tutores y tokens en la base de datos de WordPress.
+- Almacenamiento de tutores y tokens en la base de datos de WordPress; las citas se gestionan directamente en Google Calendar.
 - Importación masiva de tutores y alumnos de reserva mediante archivos XLSX de Excel.
 
 ## Requisitos

--- a/includes/Frontend/AjaxHandlers.php
+++ b/includes/Frontend/AjaxHandlers.php
@@ -215,10 +215,11 @@ class AjaxHandlers {
         }
 
         $alumnos_reserva_table = $wpdb->prefix . 'alumnos_reserva';
-        $alumno = $wpdb->get_row($wpdb->prepare("SELECT tiene_cita FROM {$alumnos_reserva_table} WHERE dni = %s AND email = %s", $dni, $email));
+        $alumno = $wpdb->get_row($wpdb->prepare("SELECT email FROM {$alumnos_reserva_table} WHERE dni = %s", $dni));
 
-        if ($alumno) {
-            if (intval($alumno->tiene_cita) === 0) {
+        if ($alumno && strcasecmp($alumno->email, $email) === 0) {
+            $events = CalendarService::get_events_by_dni($dni);
+            if (empty($events)) {
                 wp_send_json_success('Datos verificados.');
             } else {
                 wp_send_json_error('El DNI introducido ya tiene una cita registrada. Si necesitas otra cita, por favor, contacta con la administración.');
@@ -310,39 +311,6 @@ class AjaxHandlers {
         if ($event) {
             error_log('TutoriasBooking: ajax_process_booking() - Evento de Google Calendar creado con éxito. Event ID: ' . $event->id . ', Meet Link: ' . $event->hangoutLink);
 
-            $table_name = $wpdb->prefix . 'alumnos_reserva';
-
-            $existing_student = $wpdb->get_row(
-                $wpdb->prepare(
-                    "SELECT id FROM {$table_name} WHERE dni = %s",
-                    $dni
-                )
-            );
-
-            if ($existing_student) {
-                $wpdb->update(
-                    $table_name,
-                    ['tiene_cita' => 1],
-                    ['id' => $existing_student->id],
-                    ['%d'],
-                    ['%d']
-                );
-                $reservation_id = $existing_student->id;
-            } else {
-                $wpdb->insert(
-                    $table_name,
-                    [
-                        'dni'        => $dni,
-                        'email'      => $email,
-                        'nombre'     => $nombreAlumno,
-                        'apellido'   => $apellidoAlumno,
-                        'tiene_cita' => 1
-                    ],
-                    ['%s', '%s', '%s', '%s', '%d']
-                );
-                $reservation_id = $wpdb->insert_id;
-            }
-            error_log('TutoriasBooking: ajax_process_booking() - Registro actualizado. ID: ' . $reservation_id);
             // Calcular el día de la semana de la fecha del examen
             $day_of_week = date_i18n('l', strtotime($exam_date));
 
@@ -360,7 +328,6 @@ class AjaxHandlers {
                 'message'            => 'Reserva confirmada con éxito. Se ha enviado una invitación por correo electrónico.',
                 'meet_link'          => $event->hangoutLink,
                 'event_id'           => $event->id,
-                'reservation_id'     => $reservation_id,
                 'exam_date'          => $exam_date,
                 'start_time'         => $start_time,
                 'end_time'           => $end_time,


### PR DESCRIPTION
## Summary
- add update, delete and search helpers for Google Calendar events
- verify student bookings directly against Calendar and avoid storing reservations in the DB
- clarify documentation that appointments live in Google Calendar

## Testing
- `php -l includes/Google/CalendarService.php`
- `php -l includes/Frontend/AjaxHandlers.php`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b7e8c0589c832f871c90a93700b007