### PR TITLE
Manage appointments directly from Google Calendar

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -1,0 +1,65 @@
+jQuery(function($){
+    $('#tb-events-form').on('submit', function(e){
+        e.preventDefault();
+        var tutor = $('#tb_events_tutor').val();
+        var start = $('#tb_events_start').val();
+        var end   = $('#tb_events_end').val();
+        $('#tb-events-table tbody').empty();
+        $.post(ajaxurl, {
+            action: 'tb_list_events',
+            tutor_id: tutor,
+            start_date: start,
+            end_date: end,
+            nonce: tbEventsData.nonce
+        }, function(res){
+            if(res.success){
+                res.data.forEach(function(ev){
+                    var row = '<tr data-event-id="'+ev.id+'">';
+                    row += '<td><input type="text" class="tb-event-summary" value="'+(ev.summary||'')+'"></td>';
+                    row += '<td><input type="datetime-local" class="tb-event-start" value="'+ev.start.replace(' ','T')+'"></td>';
+                    row += '<td><input type="datetime-local" class="tb-event-end" value="'+ev.end.replace(' ','T')+'"></td>';
+                    row += '<td><button type="button" class="tb-button tb-save-event">Guardar</button>';
+                    row += ' <button type="button" class="tb-button tb-button-danger tb-delete-event">Eliminar</button></td>';
+                    row += '</tr>';
+                    $('#tb-events-table tbody').append(row);
+                });
+            } else {
+                alert(res.data || 'Error al obtener eventos');
+            }
+        });
+    });
+
+    $('#tb-events-table').on('click', '.tb-save-event', function(){
+        var row = $(this).closest('tr');
+        $.post(ajaxurl, {
+            action: 'tb_update_event',
+            tutor_id: $('#tb_events_tutor').val(),
+            event_id: row.data('event-id'),
+            summary: row.find('.tb-event-summary').val(),
+            start: row.find('.tb-event-start').val(),
+            end: row.find('.tb-event-end').val(),
+            nonce: tbEventsData.nonce
+        }, function(res){
+            if(!res.success){
+                alert(res.data || 'Error al guardar');
+            }
+        });
+    });
+
+    $('#tb-events-table').on('click', '.tb-delete-event', function(){
+        if(!confirm('¿Eliminar esta cita?')) return;
+        var row = $(this).closest('tr');
+        $.post(ajaxurl, {
+            action: 'tb_delete_event',
+            tutor_id: $('#tb_events_tutor').val(),
+            event_id: row.data('event-id'),
+            nonce: tbEventsData.nonce
+        }, function(res){
+            if(res.success){
+                row.remove();
+            } else {
+                alert(res.data || 'Error al eliminar');
+            }
+        });
+    });
+});

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -24,6 +24,7 @@ class AdminMenu {
         $admin_css    = TB_PLUGIN_DIR . 'assets/css/admin.css';
         $frontend_css = TB_PLUGIN_DIR . 'assets/css/frontend.css';
         $admin_js     = TB_PLUGIN_DIR . 'assets/js/admin.js';
+        $events_js    = TB_PLUGIN_DIR . 'assets/js/events.js';
 
         wp_enqueue_style(
             'tb-admin',
@@ -55,6 +56,22 @@ class AdminMenu {
             [
                 'ajax_nonce' => wp_create_nonce('tb_get_day_availability'),
                 'maxMonths'  => TB_MAX_MONTHS,
+            ]
+        );
+
+        wp_enqueue_script(
+            'tb-events',
+            TB_PLUGIN_URL . 'assets/js/events.js',
+            ['jquery'],
+            file_exists($events_js) ? filemtime($events_js) : false,
+            true
+        );
+
+        wp_localize_script(
+            'tb-events',
+            'tbEventsData',
+            [
+                'nonce' => wp_create_nonce('tb_events_nonce'),
             ]
         );
     }

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -6,6 +6,9 @@ use TutoriasBooking\Google\CalendarService;
 class AjaxHandlers {
     public static function init() {
         add_action('wp_ajax_tb_get_day_availability', [self::class, 'ajax_get_day_availability']);
+        add_action('wp_ajax_tb_list_events', [self::class, 'ajax_list_events']);
+        add_action('wp_ajax_tb_update_event', [self::class, 'ajax_update_event']);
+        add_action('wp_ajax_tb_delete_event', [self::class, 'ajax_delete_event']);
     }
 
     public static function ajax_get_day_availability() {
@@ -31,5 +34,83 @@ class AjaxHandlers {
             }
         }
         wp_send_json_success($slots);
+    }
+
+    public static function ajax_list_events() {
+        check_ajax_referer('tb_events_nonce', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permisos insuficientes.');
+        }
+        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $start = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
+        $end   = isset($_POST['end_date']) ? sanitize_text_field($_POST['end_date']) : '';
+        if (!$tutor_id || empty($start) || empty($end)) {
+            wp_send_json_error('Datos incompletos.');
+        }
+        $events = CalendarService::get_calendar_events($tutor_id, $start, $end);
+        $madridTz = new \DateTimeZone('Europe/Madrid');
+        $data = [];
+        foreach ($events as $ev) {
+            if (isset($ev->start->dateTime) && isset($ev->end->dateTime)) {
+                $startObj = new \DateTime($ev->start->dateTime);
+                $startObj->setTimezone($madridTz);
+                $endObj   = new \DateTime($ev->end->dateTime);
+                $endObj->setTimezone($madridTz);
+                $data[] = [
+                    'id'      => $ev->id,
+                    'summary' => $ev->summary,
+                    'start'   => $startObj->format('Y-m-d H:i'),
+                    'end'     => $endObj->format('Y-m-d H:i'),
+                ];
+            }
+        }
+        wp_send_json_success($data);
+    }
+
+    public static function ajax_update_event() {
+        check_ajax_referer('tb_events_nonce', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permisos insuficientes.');
+        }
+        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $event_id = isset($_POST['event_id']) ? sanitize_text_field($_POST['event_id']) : '';
+        $summary  = isset($_POST['summary']) ? sanitize_text_field($_POST['summary']) : '';
+        $start    = isset($_POST['start']) ? sanitize_text_field($_POST['start']) : '';
+        $end      = isset($_POST['end']) ? sanitize_text_field($_POST['end']) : '';
+        if (!$tutor_id || empty($event_id) || empty($start) || empty($end)) {
+            wp_send_json_error('Datos incompletos.');
+        }
+        $madrid = new \DateTimeZone('Europe/Madrid');
+        $utc    = new \DateTimeZone('UTC');
+        try {
+            $startObj = new \DateTime($start, $madrid);
+            $endObj   = new \DateTime($end, $madrid);
+            $startUtc = $startObj->setTimezone($utc)->format('c');
+            $endUtc   = $endObj->setTimezone($utc)->format('c');
+        } catch (\Exception $e) {
+            wp_send_json_error('Formato de fecha inválido.');
+        }
+        $res = CalendarService::update_calendar_event($tutor_id, $event_id, $summary, null, $startUtc, $endUtc);
+        if (is_wp_error($res)) {
+            wp_send_json_error($res->get_error_message());
+        }
+        wp_send_json_success();
+    }
+
+    public static function ajax_delete_event() {
+        check_ajax_referer('tb_events_nonce', 'nonce');
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error('Permisos insuficientes.');
+        }
+        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $event_id = isset($_POST['event_id']) ? sanitize_text_field($_POST['event_id']) : '';
+        if (!$tutor_id || empty($event_id)) {
+            wp_send_json_error('Datos incompletos.');
+        }
+        $res = CalendarService::delete_calendar_event($tutor_id, $event_id);
+        if (is_wp_error($res)) {
+            wp_send_json_error($res->get_error_message());
+        }
+        wp_send_json_success();
     }
 }

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -135,4 +135,28 @@
             <p><em>La tabla de alumnos no está disponible. Activa el plugin nuevamente.</em></p>
         <?php endif; ?>
     </section>
+
+    <hr>
+
+    <h1 class="tb-title">Gestión de Citas</h1>
+
+    <section class="tb-section">
+        <form id="tb-events-form" class="tb-form">
+            <select id="tb_events_tutor">
+                <?php foreach ($tutores as $t): ?>
+                    <option value="<?php echo esc_attr($t->id); ?>"><?php echo esc_html($t->nombre); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <input type="date" id="tb_events_start" required>
+            <input type="date" id="tb_events_end" required>
+            <button type="submit" class="tb-button">Ver Citas</button>
+        </form>
+
+        <table id="tb-events-table" class="tb-table">
+            <thead>
+                <tr><th>Título</th><th>Inicio</th><th>Fin</th><th>Acciones</th></tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </section>
 </div>


### PR DESCRIPTION
## Summary
- Allow updating and deleting Google Calendar events via new service helpers and admin AJAX actions.
- Verify DNI against existing calendar events and avoid storing bookings in the database.
- Add admin interface with JS to list, edit and remove appointments.

## Testing
- `php -l includes/Google/CalendarService.php`
- `php -l includes/Frontend/AjaxHandlers.php`
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l includes/Admin/AdminMenu.php`
- `php -l templates/admin/admin-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7f4907650832f98f308dbce867046