### PR TITLE
Skip availability slots in admin event listings

### DIFF
--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -62,8 +62,8 @@ class CalendarService {
         return $available;
     }
 
-    public static function get_busy_calendar_events($tutor_id, $start_date, $end_date) {
-        $events = self::get_calendar_events($tutor_id, $start_date, $end_date);
+    public static function get_busy_calendar_events($tutor_id, $start_date, $end_date, $query = '') {
+        $events = self::get_calendar_events($tutor_id, $start_date, $end_date, $query);
         $busy = [];
         foreach ($events as $event) {
             if (!isset($event->summary) || trim(strtoupper($event->summary)) !== 'DISPONIBLE') {


### PR DESCRIPTION
## Summary
- Use `CalendarService::get_busy_calendar_events` to fetch events.
- Ignore events titled `DISPONIBLE` so availability slots aren't listed.

## Testing
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l includes/Google/CalendarService.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7ff64e288832fbbf29f85299a513a