### PR TITLE
Include tutor ID with admin event actions

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -24,7 +24,7 @@ jQuery(function($){
         $.post(ajaxurl, data, function(res){
             if(res.success){
                 res.data.forEach(function(ev){
-                    var row = '<tr data-event-id="'+ev.id+'">';
+                    var row = '<tr data-event-id="'+ev.id+'" data-tutor-id="'+ev.tutor_id+'">';
                     row += '<td><input type="text" class="tb-event-summary" value="'+(ev.summary||'')+'"></td>';
                     row += '<td><input type="datetime-local" class="tb-event-start" value="'+ev.start.replace(' ','T')+'"></td>';
                     row += '<td><input type="datetime-local" class="tb-event-end" value="'+ev.end.replace(' ','T')+'"></td>';
@@ -43,7 +43,7 @@ jQuery(function($){
         var row = $(this).closest('tr');
         $.post(ajaxurl, {
             action: 'tb_update_event',
-            tutor_id: $('#tb_events_tutor').val(),
+            tutor_id: row.data('tutor-id'),
             event_id: row.data('event-id'),
             summary: row.find('.tb-event-summary').val(),
             start: row.find('.tb-event-start').val(),
@@ -61,7 +61,7 @@ jQuery(function($){
         var row = $(this).closest('tr');
         $.post(ajaxurl, {
             action: 'tb_delete_event',
-            tutor_id: $('#tb_events_tutor').val(),
+            tutor_id: row.data('tutor-id'),
             event_id: row.data('event-id'),
             nonce: tbEventsData.nonce
         }, function(res){

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -42,7 +42,7 @@ class AjaxHandlers {
             wp_send_json_error('Permisos insuficientes.');
         }
         global $wpdb;
-        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $tutor_id = isset($_POST['tutor_id']) ? intval(sanitize_text_field($_POST['tutor_id'])) : 0;
         $startRaw = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
         $endRaw   = isset($_POST['end_date']) ? sanitize_text_field($_POST['end_date']) : '';
         $user_dni = isset($_POST['user_dni']) ? sanitize_text_field($_POST['user_dni']) : '';
@@ -100,6 +100,7 @@ class AjaxHandlers {
                         'summary' => $ev->summary,
                         'start'   => $startObj->format('Y-m-d H:i'),
                         'end'     => $endObj->format('Y-m-d H:i'),
+                        'tutor_id'=> $tid,
                     ];
                 }
             }
@@ -113,7 +114,7 @@ class AjaxHandlers {
         if (!current_user_can('manage_options')) {
             wp_send_json_error('Permisos insuficientes.');
         }
-        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $tutor_id = isset($_POST['tutor_id']) ? intval(sanitize_text_field($_POST['tutor_id'])) : 0;
         $event_id = isset($_POST['event_id']) ? sanitize_text_field($_POST['event_id']) : '';
         $summary  = isset($_POST['summary']) ? sanitize_text_field($_POST['summary']) : '';
         $start    = isset($_POST['start']) ? sanitize_text_field($_POST['start']) : '';
@@ -143,7 +144,7 @@ class AjaxHandlers {
         if (!current_user_can('manage_options')) {
             wp_send_json_error('Permisos insuficientes.');
         }
-        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $tutor_id = isset($_POST['tutor_id']) ? intval(sanitize_text_field($_POST['tutor_id'])) : 0;
         $event_id = isset($_POST['event_id']) ? sanitize_text_field($_POST['event_id']) : '';
         if (!$tutor_id || empty($event_id)) {
             wp_send_json_error('Datos incompletos.');


### PR DESCRIPTION
## Summary
- include `tutor_id` in event data returned by `ajax_list_events`
- track each event's tutor in `events.js` rows and send with update/delete
- sanitize and use `tutor_id` in update and delete handlers

## Testing
- `php -l includes/Admin/AjaxHandlers.php`
- `node --check assets/js/events.js`
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b80df73c50832f9304e55c7422da25