### PR TITLE
Add admin event creation form and handler

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -1,4 +1,25 @@
 jQuery(function($){
+    $('#tb-create-event-form').on('submit', function(e){
+        e.preventDefault();
+        var data = {
+            action: 'tb_create_event',
+            tutor_id: $('#tb_create_tutor').val(),
+            alumno_id: $('#tb_create_alumno').val(),
+            start: $('#tb_create_start').val(),
+            end: $('#tb_create_end').val(),
+            summary: $('#tb_create_title').val(),
+            description: $('#tb_create_desc').val(),
+            nonce: tbEventsData.nonce
+        };
+        $.post(ajaxurl, data, function(res){
+            if(res.success){
+                alert('Cita creada');
+            } else {
+                alert(res.data || 'Error al crear la cita');
+            }
+        });
+    });
+
     $('#tb-events-form').on('submit', function(e){
         e.preventDefault();
         var tutor   = $('#tb_events_tutor').val();

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -141,6 +141,26 @@
     <h1 class="tb-title">Gestión de Citas</h1>
 
     <section class="tb-section">
+        <form id="tb-create-event-form" class="tb-form">
+            <select id="tb_create_tutor" required>
+                <option value="">Seleccione tutor</option>
+                <?php foreach ($tutores as $t): ?>
+                    <option value="<?php echo esc_attr($t->id); ?>"><?php echo esc_html($t->nombre); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <select id="tb_create_alumno" required>
+                <option value="">Seleccione alumno</option>
+                <?php foreach ($alumnos_reserva as $alumno): ?>
+                    <option value="<?php echo esc_attr($alumno->id); ?>"><?php echo esc_html($alumno->nombre . ' ' . $alumno->apellido); ?></option>
+                <?php endforeach; ?>
+            </select>
+            <input type="datetime-local" id="tb_create_start" required>
+            <input type="datetime-local" id="tb_create_end" required>
+            <input type="text" id="tb_create_title" placeholder="Título" required>
+            <input type="text" id="tb_create_desc" placeholder="Descripción">
+            <button type="submit" class="tb-button">Crear Cita</button>
+        </form>
+
         <form id="tb-events-form" class="tb-form">
             <select id="tb_events_tutor">
                 <option value="">Todos los tutores</option>


### PR DESCRIPTION
## Summary
- add form to create tutoring events in admin panel
- send form data via AJAX to new endpoint
- implement backend handler that creates calendar event and marks student

## Testing
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l templates/admin/admin-page.php`
- `node --check assets/js/events.js`


------
https://chatgpt.com/codex/tasks/task_e_68b80ef6a8b0832fb9fbeb2ef5d50aca