### PR TITLE
Show success notice after event update or delete

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -116,3 +116,19 @@
     gap: 10px;
     margin-bottom: 10px;
 }
+
+.tb-notice {
+    margin: 10px 0;
+    padding: 10px;
+    border-left: 4px solid;
+}
+
+.tb-notice-success {
+    background-color: #f0f6f0;
+    border-color: #46b450;
+}
+
+.tb-notice-error {
+    background-color: #fbeaea;
+    border-color: #dc3232;
+}

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -1,4 +1,17 @@
 jQuery(function($){
+    function tbShowNotice(message, type){
+        var $wrapper = $('.tb-admin-wrapper');
+        if(!$wrapper.length){
+            alert(message);
+            return;
+        }
+        var $notice = $('<div class="tb-notice tb-notice-' + type + '"><p>' + message + '</p></div>');
+        $wrapper.prepend($notice);
+        setTimeout(function(){
+            $notice.fadeOut(400, function(){ $(this).remove(); });
+        }, 3000);
+    }
+
     $('#tb-create-event-form').on('submit', function(e){
         e.preventDefault();
         var data = {
@@ -71,7 +84,9 @@ jQuery(function($){
             end: row.find('.tb-event-end').val(),
             nonce: tbEventsData.nonce
         }, function(res){
-            if(!res.success){
+            if(res.success){
+                tbShowNotice('Cita actualizada', 'success');
+            } else {
                 alert(res.data || 'Error al guardar');
             }
         });
@@ -88,6 +103,7 @@ jQuery(function($){
         }, function(res){
             if(res.success){
                 row.remove();
+                tbShowNotice('Cita eliminada', 'success');
             } else {
                 alert(res.data || 'Error al eliminar');
             }


### PR DESCRIPTION
## Summary
- display visual confirmation when events are updated or removed in the admin panel
- add reusable notice helper and styles for success and error messages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_68b811047a54832fa0af1f343abda15f