### PR TITLE
Mostrar enlace de Hangout y asistentes en tabla de eventos

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -62,6 +62,13 @@ jQuery(function($){
                     row += '<td><input type="text" class="tb-event-summary" value="'+(ev.summary||'')+'"></td>';
                     row += '<td><input type="datetime-local" class="tb-event-start" value="'+ev.start.replace(' ','T')+'"></td>';
                     row += '<td><input type="datetime-local" class="tb-event-end" value="'+ev.end.replace(' ','T')+'"></td>';
+                    row += '<td>';
+                    if(ev.hangoutLink){
+                        row += '<a href="'+ev.hangoutLink+'" target="_blank" class="tb-hangout-link">🔗</a> ';
+                        row += '<button type="button" class="tb-button tb-copy-link" data-link="'+ev.hangoutLink+'">Copiar</button>';
+                    }
+                    row += '</td>';
+                    row += '<td>' + (Array.isArray(ev.attendees) ? ev.attendees.join('<br>') : '') + '</td>';
                     row += '<td><button type="button" class="tb-button tb-save-event">Guardar</button>';
                     row += ' <button type="button" class="tb-button tb-button-danger tb-delete-event">Eliminar</button></td>';
                     row += '</tr>';
@@ -107,6 +114,18 @@ jQuery(function($){
             } else {
                 alert(res.data || 'Error al eliminar');
             }
+        });
+    });
+
+    $('#tb-events-table').on('click', '.tb-copy-link', function(){
+        var link = $(this).data('link');
+        if(!link){
+            return;
+        }
+        navigator.clipboard.writeText(link).then(function(){
+            tbShowNotice('Enlace copiado', 'success');
+        }).catch(function(){
+            alert('No se pudo copiar el enlace');
         });
     });
 });

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -102,6 +102,10 @@ class AjaxHandlers {
                         'start'   => $startObj->format('Y-m-d H:i'),
                         'end'     => $endObj->format('Y-m-d H:i'),
                         'tutor_id'=> $tid,
+                        'hangoutLink' => isset($ev->hangoutLink) ? $ev->hangoutLink : '',
+                        'attendees'   => isset($ev->attendees) ? array_map(function($a){
+                            return isset($a->email) ? $a->email : '';
+                        }, $ev->attendees) : [],
                     ];
                 }
             }

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -183,7 +183,7 @@
 
         <table id="tb-events-table" class="tb-table">
             <thead>
-                <tr><th>Título</th><th>Inicio</th><th>Fin</th><th>Acciones</th></tr>
+                <tr><th>Título</th><th>Inicio</th><th>Fin</th><th>Enlace</th><th>Asistentes</th><th>Acciones</th></tr>
             </thead>
             <tbody></tbody>
         </table>


### PR DESCRIPTION
## Summary
- Añadir `hangoutLink` y `attendees` al listado de eventos en AJAX
- Mostrar enlace y correos de asistentes en la tabla de la página de administración
- Permitir copiar al portapapeles el enlace de la reunión desde la tabla

## Testing
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l templates/admin/admin-page.php`
- `node --check assets/js/events.js && echo 'JS OK'`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68b811e1526c832fadb778e64e485e85