### PR TITLE
Show complete appointment info in admin

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -25,33 +25,17 @@ jQuery(function($){
             if(res.success){
                 res.data.forEach(function(ev){
                     var row = '<tr data-event-id="'+ev.id+'" data-tutor-id="'+ev.tutor_id+'">';
-                    row += '<td><input type="text" class="tb-event-summary" value="'+(ev.summary||'')+'"></td>';
-                    row += '<td><input type="datetime-local" class="tb-event-start" value="'+ev.start.replace(' ','T')+'"></td>';
-                    row += '<td><input type="datetime-local" class="tb-event-end" value="'+ev.end.replace(' ','T')+'"></td>';
-                    row += '<td><button type="button" class="tb-button tb-save-event">Guardar</button>';
-                    row += ' <button type="button" class="tb-button tb-button-danger tb-delete-event">Eliminar</button></td>';
+                    row += '<td>'+(ev.user||'')+'</td>';
+                    row += '<td>'+(ev.tutor||'')+'</td>';
+                    row += '<td>'+ev.start+' - '+ev.end+'</td>';
+                    var link = ev.url ? '<a href="'+ev.url+'" target="_blank">'+ev.url+'</a>' : '';
+                    row += '<td>'+link+'</td>';
+                    row += '<td><button type="button" class="tb-button tb-button-danger tb-delete-event">Eliminar</button></td>';
                     row += '</tr>';
                     $('#tb-events-table tbody').append(row);
                 });
             } else {
                 alert(res.data || 'Error al obtener eventos');
-            }
-        });
-    });
-
-    $('#tb-events-table').on('click', '.tb-save-event', function(){
-        var row = $(this).closest('tr');
-        $.post(ajaxurl, {
-            action: 'tb_update_event',
-            tutor_id: row.data('tutor-id'),
-            event_id: row.data('event-id'),
-            summary: row.find('.tb-event-summary').val(),
-            start: row.find('.tb-event-start').val(),
-            end: row.find('.tb-event-end').val(),
-            nonce: tbEventsData.nonce
-        }, function(res){
-            if(!res.success){
-                alert(res.data || 'Error al guardar');
             }
         });
     });

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -82,6 +82,8 @@ class AjaxHandlers {
         foreach ($tutor_ids as $tid) {
             $events = CalendarService::get_busy_calendar_events($tid, $start, $end, $user_q);
 
+            $tutor_name = $wpdb->get_var($wpdb->prepare("SELECT nombre FROM {$wpdb->prefix}tutores WHERE id=%d", $tid));
+
             foreach ($events as $ev) {
                 if (isset($ev->summary) && strtoupper(trim($ev->summary)) === 'DISPONIBLE') {
                     continue; // omitir slots de disponibilidad
@@ -91,11 +93,19 @@ class AjaxHandlers {
                     $startObj->setTimezone($madridTz);
                     $endObj   = new \DateTime($ev->end->dateTime);
                     $endObj->setTimezone($madridTz);
+
+                    $user_name = '';
+                    if (!empty($ev->description) && preg_match('/Nombre:\s*(.*)\n/', $ev->description, $m)) {
+                        $user_name = trim($m[1]);
+                    }
+
                     $data[] = [
                         'id'       => $ev->id,
-                        'summary'  => $ev->summary,
+                        'user'     => $user_name,
+                        'tutor'    => $tutor_name,
                         'start'    => $startObj->format('Y-m-d H:i'),
                         'end'      => $endObj->format('Y-m-d H:i'),
+                        'url'      => $ev->hangoutLink ?? '',
                         'tutor_id' => $tid,
                     ];
                 }

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -163,7 +163,7 @@
 
         <table id="tb-events-table" class="tb-table">
             <thead>
-                <tr><th>Título</th><th>Inicio</th><th>Fin</th><th>Acciones</th></tr>
+                <tr><th>Usuario</th><th>Tutor</th><th>Tramo</th><th>Cita</th><th>Acciones</th></tr>
             </thead>
             <tbody></tbody>
         </table>


### PR DESCRIPTION
## Summary
- Display student, tutor, time range, Meet link and delete action in appointment table
- Include student name, tutor name and meet URL in event listing response
- Remove inline editing of events from admin interface

## Testing
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l templates/admin/admin-page.php`
- `node --check assets/js/events.js`


------
https://chatgpt.com/codex/tasks/task_e_68b940d96a94832fa8684a2d2bfeae18