### PR TITLE
Add admin editing with shared calendar utilities

### DIFF
--- a/assets/js/admin-edit.js
+++ b/assets/js/admin-edit.js
@@ -1,0 +1,83 @@
+jQuery(function($){
+  var selectedSlot = null;
+
+  $('#tb-events-table').on('click', '.tb-edit-event', function(){
+    var row = $(this).closest('tr');
+    var tutorId = row.data('tutor-id');
+    var eventId = row.data('event-id');
+
+    var today = new Date();
+    var startDate = tbCalendarUtils.formatDate(today);
+    var endDateObj = new Date(today);
+    endDateObj.setFullYear(endDateObj.getFullYear() + 1);
+    var endDate = tbCalendarUtils.formatDate(endDateObj);
+
+    $.post(ajaxurl, {
+      action: 'tb_get_available_slots',
+      tutor_id: tutorId,
+      start_date: startDate,
+      end_date: endDate,
+      nonce: tbEditData.nonce
+    }, function(res){
+      if(res.success){
+        window.slotsByDate = {};
+        $.each(res.data, function(i, slot){
+          if(!window.slotsByDate[slot.date]) window.slotsByDate[slot.date] = [];
+          window.slotsByDate[slot.date].push(slot);
+        });
+        window.calendarStartDate = new Date(startDate + 'T00:00:00');
+        window.calendarEndDate   = new Date(endDate + 'T00:00:00');
+        window.currentMonthDate  = new Date(startDate + 'T00:00:00');
+        window.selectedDate = null;
+
+        if(!$('#tb_edit_modal').length){
+          $('body').append('<div id="tb_edit_modal" class="tb-slots-overlay" style="display:none"><div class="tb-slots-content"><div id="tb_calendar"></div><p id="tb_selected_slot"></p><button type="button" id="tb_edit_save" class="tb-button" disabled>Guardar</button> <button type="button" id="tb_edit_cancel" class="tb-button tb-button-danger">Cancelar</button></div></div>');
+        }
+        if(!$('#tb_slots_overlay').length){
+          $('body').append('<div id="tb_slots_overlay" class="tb-slots-overlay" style="display:none"><div id="tb_slots_container" class="tb-slots-content"></div></div>');
+        }
+
+        window.tbCalendarSelector = '#tb_calendar';
+        window.tbOnDaySelected = function(date){
+          $('#tb_edit_save').prop('disabled', true);
+          tbCalendarUtils.renderSlotsForDate(date);
+        };
+        window.tbOnSlotSelected = function(input){
+          selectedSlot = input;
+          $('#tb_selected_slot').text('Seleccionado: ' + input.data('date') + ' ' + input.data('start') + ' - ' + input.data('end'));
+          $('#tb_edit_save').prop('disabled', false);
+        };
+
+        tbCalendarUtils.renderCalendar(window.currentMonthDate);
+        $('#tb_edit_modal').show().css('display','flex');
+
+        $('#tb_edit_cancel').off('click').on('click', function(){
+          $('#tb_edit_modal').hide();
+        });
+
+        $('#tb_edit_save').off('click').on('click', function(){
+          if(!selectedSlot) return;
+          var start = selectedSlot.data('date') + ' ' + selectedSlot.data('start');
+          var end   = selectedSlot.data('date') + ' ' + selectedSlot.data('end');
+          $.post(ajaxurl, {
+            action: 'tb_update_event',
+            tutor_id: tutorId,
+            event_id: eventId,
+            start: start,
+            end: end,
+            nonce: tbEventsData.nonce
+          }, function(resp){
+            if(resp.success){
+              row.find('td').eq(2).text(start + ' - ' + end);
+              $('#tb_edit_modal').hide();
+            } else {
+              alert(resp.data || 'Error al actualizar');
+            }
+          });
+        });
+      } else {
+        alert(res.data || 'Error al obtener disponibilidad');
+      }
+    });
+  });
+});

--- a/assets/js/calendar-utils.js
+++ b/assets/js/calendar-utils.js
@@ -1,0 +1,130 @@
+(function($){
+  function formatDate(date) {
+    var d = new Date(date),
+        month = '' + (d.getMonth() + 1),
+        day = '' + d.getDate(),
+        year = d.getFullYear();
+    if (month.length < 2) month = '0' + month;
+    if (day.length < 2) day = '0' + day;
+    return [year, month, day].join('-');
+  }
+
+  function renderSlotsForDate(date) {
+    var overlay = $('#tb_slots_overlay');
+    var slotsContainer = $('#tb_slots_container');
+    slotsContainer.empty();
+    var slotsForThisDate = window.slotsByDate[date];
+
+    if (slotsForThisDate && slotsForThisDate.length > 0) {
+      var dayHtml = '<button type="button" id="tb_close_slots" class="tb-close-btn">&times;</button>';
+      dayHtml += '<div class="tb-day-card"><h4>' + date + '</h4><div class="tb-time-slots-list">';
+      $.each(slotsForThisDate, function(idx, slot){
+        dayHtml += '<label class="tb-time-slot-label">';
+        dayHtml += '<input type="radio" name="selected_slot" value="' + slot.start_time + '-' + slot.end_time + '" data-start="' + slot.start_time + '" data-end="' + slot.end_time + '" data-date="' + slot.date + '">';
+        dayHtml += slot.start_time + ' - ' + slot.end_time;
+        dayHtml += '</label>';
+      });
+      dayHtml += '</div></div>';
+      slotsContainer.html(dayHtml);
+    } else {
+      slotsContainer.html('<button type="button" id="tb_close_slots" class="tb-close-btn">&times;</button><p class="tb-message tb-message-info">No hay disponibilidad para la fecha seleccionada.</p>');
+    }
+
+    overlay.show().css('display','flex');
+
+    overlay.off('click').on('click', function(e){
+      if (e.target.id === 'tb_slots_overlay') overlay.hide();
+    });
+    $('#tb_close_slots').on('click', function(){ overlay.hide(); });
+
+    $('input[name="selected_slot"]').change(function(){
+      if (typeof window.tbOnSlotSelected === 'function') {
+        window.tbOnSlotSelected($(this));
+      }
+      overlay.hide();
+    });
+  }
+
+  function renderCalendar(monthDate) {
+    var calendar = $(window.tbCalendarSelector || '#tb_calendar');
+    var monthNames = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
+    var dayNames = ['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'];
+    var month = monthDate.getMonth();
+    var year = monthDate.getFullYear();
+
+    var calendarHtml = '<div class="tb-calendar-month">';
+    calendarHtml += '<div class="tb-calendar-nav">';
+    calendarHtml += '<button id="tb_prev_month" class="tb-nav-btn">&lt;</button>';
+    calendarHtml += '<span class="tb-calendar-month-name">' + monthNames[month] + ' ' + year + '</span>';
+    calendarHtml += '<button id="tb_next_month" class="tb-nav-btn">&gt;</button>';
+    calendarHtml += '</div>';
+
+    calendarHtml += '<div class="tb-calendar-week-day-names">';
+    $.each(dayNames, function(_, dn){
+      calendarHtml += '<div class="tb-calendar-week-day">' + dn + '</div>';
+    });
+    calendarHtml += '</div>';
+
+    calendarHtml += '<div class="tb-calendar-days">';
+    var firstDayIndex = new Date(year, month, 1).getDay();
+    for (var i = 0; i < firstDayIndex; i++) {
+      calendarHtml += '<div class="tb-calendar-day tb-empty"></div>';
+    }
+    var daysInMonth = new Date(year, month + 1, 0).getDate();
+    for (var d = 1; d <= daysInMonth; d++) {
+      var dateObj = new Date(year, month, d);
+      var dateStr = formatDate(dateObj);
+      if (dateObj < window.calendarStartDate || dateObj > window.calendarEndDate) {
+        calendarHtml += '<div class="tb-calendar-day tb-out-of-range">' + d + '</div>';
+      } else {
+        var available = !!window.slotsByDate[dateStr];
+        var classes = 'tb-calendar-day' + (available ? ' tb-day-available' : ' tb-day-unavailable');
+        if (window.selectedDate === dateStr) classes += ' tb-selected';
+        calendarHtml += '<div class="' + classes + '" data-date="' + dateStr + '">' + d + '</div>';
+      }
+    }
+    calendarHtml += '</div></div>';
+
+    calendar.html(calendarHtml);
+
+    calendar.off('click', '.tb-day-available').on('click', '.tb-day-available', function(){
+      window.selectedDate = $(this).data('date');
+      $('.tb-calendar-day', calendar).removeClass('tb-selected');
+      $(this).addClass('tb-selected');
+      if (typeof window.tbOnDaySelected === 'function') {
+        window.tbOnDaySelected(window.selectedDate);
+      }
+    });
+
+    $('#tb_prev_month').on('click', function(){
+      if (!$(this).prop('disabled')) {
+        monthDate.setMonth(monthDate.getMonth() - 1);
+        window.currentMonthDate = new Date(monthDate);
+        renderCalendar(window.currentMonthDate);
+      }
+    });
+
+    $('#tb_next_month').on('click', function(){
+      if (!$(this).prop('disabled')) {
+        monthDate.setMonth(monthDate.getMonth() + 1);
+        window.currentMonthDate = new Date(monthDate);
+        renderCalendar(window.currentMonthDate);
+      }
+    });
+
+    var prevMonthDate = new Date(year, month - 1, 1);
+    if (prevMonthDate < new Date(window.calendarStartDate.getFullYear(), window.calendarStartDate.getMonth(), 1)) {
+      $('#tb_prev_month').prop('disabled', true);
+    }
+    var nextMonthDate = new Date(year, month + 1, 1);
+    if (nextMonthDate > new Date(window.calendarEndDate.getFullYear(), window.calendarEndDate.getMonth(), 1)) {
+      $('#tb_next_month').prop('disabled', true);
+    }
+  }
+
+  window.tbCalendarUtils = {
+    formatDate: formatDate,
+    renderSlotsForDate: renderSlotsForDate,
+    renderCalendar: renderCalendar
+  };
+})(jQuery);

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -30,7 +30,8 @@ jQuery(function($){
                     row += '<td>'+ev.start+' - '+ev.end+'</td>';
                     var link = ev.url ? '<a href="'+ev.url+'" target="_blank">'+ev.url+'</a>' : '';
                     row += '<td>'+link+'</td>';
-                    row += '<td><button type="button" class="tb-button tb-button-danger tb-delete-event">Eliminar</button></td>';
+                    row += '<td><button type="button" class="tb-button tb-edit-event">Editar</button> ';
+                    row += '<button type="button" class="tb-button tb-button-danger tb-delete-event">Eliminar</button></td>';
                     row += '</tr>';
                     $('#tb-events-table tbody').append(row);
                 });

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -25,6 +25,8 @@ class AdminMenu {
         $frontend_css = TB_PLUGIN_DIR . 'assets/css/frontend.css';
         $admin_js     = TB_PLUGIN_DIR . 'assets/js/admin.js';
         $events_js    = TB_PLUGIN_DIR . 'assets/js/events.js';
+        $utils_js     = TB_PLUGIN_DIR . 'assets/js/calendar-utils.js';
+        $edit_js      = TB_PLUGIN_DIR . 'assets/js/admin-edit.js';
 
         wp_enqueue_style(
             'tb-admin',
@@ -33,14 +35,12 @@ class AdminMenu {
             file_exists($admin_css) ? filemtime($admin_css) : false
         );
 
-        if (isset($_GET['action']) && $_GET['action'] === 'tb_assign_availability') {
-            wp_enqueue_style(
-                'tb-frontend',
-                TB_PLUGIN_URL . 'assets/css/frontend.css',
-                [],
-                file_exists($frontend_css) ? filemtime($frontend_css) : false
-            );
-        }
+        wp_enqueue_style(
+            'tb-frontend',
+            TB_PLUGIN_URL . 'assets/css/frontend.css',
+            [],
+            file_exists($frontend_css) ? filemtime($frontend_css) : false
+        );
 
         wp_enqueue_script(
             'tb-admin',
@@ -60,9 +60,17 @@ class AdminMenu {
         );
 
         wp_enqueue_script(
+            'tb-calendar-utils',
+            TB_PLUGIN_URL . 'assets/js/calendar-utils.js',
+            ['jquery'],
+            file_exists($utils_js) ? filemtime($utils_js) : false,
+            true
+        );
+
+        wp_enqueue_script(
             'tb-events',
             TB_PLUGIN_URL . 'assets/js/events.js',
-            ['jquery'],
+            ['jquery','tb-calendar-utils'],
             file_exists($events_js) ? filemtime($events_js) : false,
             true
         );
@@ -72,6 +80,22 @@ class AdminMenu {
             'tbEventsData',
             [
                 'nonce' => wp_create_nonce('tb_events_nonce'),
+            ]
+        );
+
+        wp_enqueue_script(
+            'tb-admin-edit',
+            TB_PLUGIN_URL . 'assets/js/admin-edit.js',
+            ['jquery','tb-calendar-utils'],
+            file_exists($edit_js) ? filemtime($edit_js) : false,
+            true
+        );
+
+        wp_localize_script(
+            'tb-admin-edit',
+            'tbEditData',
+            [
+                'nonce' => wp_create_nonce('tb_booking_nonce'),
             ]
         );
     }

--- a/includes/Frontend/Shortcodes.php
+++ b/includes/Frontend/Shortcodes.php
@@ -5,9 +5,11 @@ function enqueue_assets()
 {
     $css_rel = 'assets/css/frontend.css';
     $js_rel  = 'assets/js/frontend.js';
+    $utils_rel = 'assets/js/calendar-utils.js';
 
     $css_path = TB_PLUGIN_DIR . $css_rel;
     $js_path  = TB_PLUGIN_DIR . $js_rel;
+    $utils_path = TB_PLUGIN_DIR . $utils_rel;
 
     // Ensure our stylesheet loads after Elementor's if present
     $style_deps = [];
@@ -39,7 +41,17 @@ function enqueue_assets()
         $deps[] = 'google-recaptcha';
     }
 
+    $utils_version = file_exists($utils_path) ? filemtime($utils_path) : false;
+    wp_enqueue_script(
+        'tb-calendar-utils',
+        plugins_url($utils_rel, TB_PLUGIN_FILE),
+        ['jquery'],
+        $utils_version,
+        true
+    );
+
     $js_version = file_exists($js_path) ? filemtime($js_path) : false;
+    $deps[] = 'tb-calendar-utils';
     wp_enqueue_script(
         'tb-frontend',
         plugins_url($js_rel, TB_PLUGIN_FILE),

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -168,4 +168,15 @@
             <tbody></tbody>
         </table>
     </section>
+    <div id="tb_edit_modal" class="tb-slots-overlay" style="display:none">
+        <div class="tb-slots-content">
+            <div id="tb_calendar"></div>
+            <p id="tb_selected_slot"></p>
+            <button type="button" id="tb_edit_save" class="tb-button" disabled>Guardar</button>
+            <button type="button" id="tb_edit_cancel" class="tb-button tb-button-danger">Cancelar</button>
+        </div>
+    </div>
+    <div id="tb_slots_overlay" class="tb-slots-overlay" style="display:none">
+        <div id="tb_slots_container" class="tb-slots-content"></div>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- add Edit button and modal to admin events table
- introduce shared calendar-utils module used by frontend and admin
- implement admin-edit.js to reschedule events via AJAX and enqueue assets

## Testing
- `npm test` *(fails: no package.json)*
- `php -l templates/admin/admin-page.php`
- `php -l includes/Frontend/Shortcodes.php`
- `php -l includes/Admin/AdminMenu.php`
- `node --check assets/js/admin-edit.js`
- `node --check assets/js/events.js`
- `node --check assets/js/frontend.js`
- `node --check assets/js/calendar-utils.js`


------
https://chatgpt.com/codex/tasks/task_e_68bea971fd6c832f8bfdfcac4500acc4