### PR TITLE
Fix admin danger button selector

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -46,11 +46,11 @@
     background-color: #1d5e94;
 }
 
-.tb-button-danger {
-    background-color: #d63638;
+.tb-button.tb-button-danger {
+    background-color: #d63638 !important;
 }
 
-.tb-button-danger:hover {
+.tb-button.tb-button-danger:hover {
     background-color: #a12a2a;
 }
 


### PR DESCRIPTION
## Summary
- ensure danger buttons override default admin style

## Testing
- `composer test` (fails: Command "test" is not defined)
- `npm test` (fails: ENOENT Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68bfdb7ceb58832f89237073c4206c06