### PR TITLE
feat: separar tipos de cita

### DIFF
--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -47,15 +47,15 @@ class AdminController {
 
             $updated = $wpdb->update(
                 $alumnos_reserva_table,
-                ['tiene_cita' => 0],
+                ['online' => 0, 'presencial' => 0],
                 ['id' => $alumno_id],
-                ['%d'],
+                ['%d', '%d'],
                 ['%d']
             );
             if ($updated !== false) {
-                $messages[] = ['type' => 'success', 'text' => 'La reserva del alumno con ID ' . esc_html($alumno_id) . ' ha sido eliminada y el campo "Tiene Cita" se ha establecido en 0.'];
+                $messages[] = ['type' => 'success', 'text' => 'La reserva del alumno con ID ' . esc_html($alumno_id) . ' ha sido eliminada y los campos "Online" y "Presencial" se han establecido en 0.'];
             } else {
-                $messages[] = ['type' => 'error', 'text' => 'Error al actualizar el campo "Tiene Cita".'];
+                $messages[] = ['type' => 'error', 'text' => 'Error al actualizar los campos de cita.'];
             }
         }
 
@@ -101,7 +101,8 @@ class AdminController {
                             'email'      => $email_alumno,
                             'nombre'     => $nombre_alumno,
                             'apellido'   => $apellido_alumno,
-                            'tiene_cita' => 0
+                            'online'     => 0,
+                            'presencial' => 0
                         ]
                     );
                     if ($inserted) {
@@ -162,7 +163,7 @@ class AdminController {
         $tutores = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}tutores");
         $alumnos_reserva = [];
         if ($table_exists) {
-            $alumnos_reserva = $wpdb->get_results("SELECT id, dni, nombre, apellido, email, tiene_cita FROM {$alumnos_reserva_table}");
+            $alumnos_reserva = $wpdb->get_results("SELECT id, dni, nombre, apellido, email, online, presencial FROM {$alumnos_reserva_table}");
         }
 
         include TB_PLUGIN_DIR . 'templates/admin/admin-page.php';
@@ -583,7 +584,8 @@ class AdminController {
                     'email'      => $email,
                     'nombre'     => $nombre,
                     'apellido'   => $apellido,
-                    'tiene_cita' => 0
+                    'online'     => 0,
+                    'presencial' => 0
                 ]
             );
             $count++;

--- a/includes/Frontend/AjaxHandlers.php
+++ b/includes/Frontend/AjaxHandlers.php
@@ -320,14 +320,14 @@ class AjaxHandlers {
             // El evento "DISPONIBLE" original se mantiene en el calendario
             error_log('TutoriasBooking: ajax_process_booking() - Nota: el evento DISPONIBLE no se elimina y permanece en el calendario.');
 
-            // Marcar en la base de datos que el alumno ya tiene una cita
+            // Marcar en la base de datos que el alumno ya tiene una cita online
             $updated = $wpdb->update(
                 "{$wpdb->prefix}alumnos_reserva",
-                ['tiene_cita' => 1],
+                ['online' => 1],
                 ['dni' => $dni]
             );
             if ($updated === false) {
-                error_log('TutoriasBooking: ajax_process_booking() - ERROR: No se pudo actualizar tiene_cita para el DNI ' . $dni . '. ' . $wpdb->last_error);
+                error_log('TutoriasBooking: ajax_process_booking() - ERROR: No se pudo actualizar el estado de cita para el DNI ' . $dni . '. ' . $wpdb->last_error);
             }
 
             // Calcular el día de la semana de la fecha del examen

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -95,7 +95,7 @@
             <?php if (!empty($alumnos_reserva)): ?>
                 <table class="tb-table">
                     <thead>
-                        <tr><th>ID</th><th>DNI</th><th>Nombre</th><th>Apellido</th><th>Email</th><th>Tiene Cita</th><th>Acciones</th></tr>
+                        <tr><th>ID</th><th>DNI</th><th>Nombre</th><th>Apellido</th><th>Email</th><th>Online</th><th>Presencial</th><th>Acciones</th></tr>
                     </thead>
                     <tbody>
                         <?php foreach ($alumnos_reserva as $alumno): ?>
@@ -104,22 +104,23 @@
                                 <td><?php echo esc_html($alumno->dni); ?></td>
                                 <td><?php echo esc_html($alumno->nombre); ?></td>
                                 <td><?php echo esc_html($alumno->apellido); ?></td>
-                                <td><?php echo esc_html($alumno->email); ?></td>
-                                <td><?php echo $alumno->tiene_cita ? 'Sí' : '<span class="tb-alert">No</span>'; ?></td>
-                                <td>
-                                    <?php if ($alumno->tiene_cita): ?>
-                                        <form method="POST" class="tb-inline-form">
-                                            <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                            <input type="hidden" name="tb_reset_cita_id" value="<?php echo esc_attr($alumno->id); ?>">
-                                            <button type="submit" class="tb-button">Poner en 0</button>
-                                        </form>
-                                    <?php endif; ?>
-                                    <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este alumno?');">
-                                        <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                        <input type="hidden" name="tb_delete_alumno_id" value="<?php echo esc_attr($alumno->id); ?>">
-                                        <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
-                                    </form>
-                                </td>
+                                  <td><?php echo esc_html($alumno->email); ?></td>
+                                  <td><?php echo $alumno->online ? 'Sí' : '<span class="tb-alert">No</span>'; ?></td>
+                                  <td><?php echo $alumno->presencial ? 'Sí' : '<span class="tb-alert">No</span>'; ?></td>
+                                  <td>
+                                      <?php if ($alumno->online || $alumno->presencial): ?>
+                                          <form method="POST" class="tb-inline-form">
+                                              <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                                              <input type="hidden" name="tb_reset_cita_id" value="<?php echo esc_attr($alumno->id); ?>">
+                                              <button type="submit" class="tb-button">Poner en 0</button>
+                                          </form>
+                                      <?php endif; ?>
+                                      <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este alumno?');">
+                                          <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                                          <input type="hidden" name="tb_delete_alumno_id" value="<?php echo esc_attr($alumno->id); ?>">
+                                          <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
+                                      </form>
+                                  </td>
                             </tr>
                         <?php endforeach; ?>
                     </tbody>

--- a/tutorias-booking.php
+++ b/tutorias-booking.php
@@ -79,5 +79,8 @@ require_once TB_PLUGIN_DIR . 'includes/Core/Loader.php';
 // Registra la función de activación del plugin.
 register_activation_hook(__FILE__, ['TutoriasBooking\\Core\\Activator', 'activate']);
 
+// Ejecuta rutinas de actualización si es necesario.
+TutoriasBooking\Core\Activator::maybe_upgrade();
+
 // Inicia la carga de todos los componentes del plugin.
 TutoriasBooking\Core\Loader::init();


### PR DESCRIPTION
## Summary
- add `online` y `presencial` to alumnos table and migration
- handle online/presencial flags when administrar alumnos
- show new flags in admin table and set online on booking

## Testing
- `php -l includes/Core/Activator.php`
- `php -l tutorias-booking.php`
- `php -l includes/Admin/AdminController.php`
- `php -l templates/admin/admin-page.php`
- `php -l includes/Frontend/AjaxHandlers.php`


------
https://chatgpt.com/codex/tasks/task_e_68c023152e60832fa7677dd12c7ae0f3