### PR TITLE
Add modality selection for availability

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -232,7 +232,13 @@ jQuery(function($){
     refreshSelected();
 
     var $form = $('#tb-time-ranges').closest('form');
+    var $modalitySelect = $('#tb_modality');
     $form.on('submit', function(e){
+        if (!$modalitySelect.val()) {
+            e.preventDefault();
+            alert('Seleccione una modalidad.');
+            return;
+        }
         var ranges = [];
         var valid = true;
         $('#tb-time-ranges .tb-time-range').each(function(){


### PR DESCRIPTION
## Summary
- add modality select when assigning availability
- append selected modality to created event summary
- validate modality selection on form submit

## Testing
- `php -l includes/Admin/AdminController.php`
- `node --check assets/js/admin.js`


------
https://chatgpt.com/codex/tasks/task_e_68c11a4fce8c832fad35f0e3bf94817b