### PR TITLE
Fix availability slots not requiring conference links

### DIFF
--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -411,7 +411,15 @@ class AdminController {
                                 } elseif ($range['modality'] === 'presencial') {
                                     $summary .= ' PRESENCIAL';
                                 }
-                                $created = CalendarService::create_calendar_event($tutor_id, $summary, '', $start_dt, $end_dt);
+                                $created = CalendarService::create_calendar_event(
+                                    $tutor_id,
+                                    $summary,
+                                    '',
+                                    $start_dt,
+                                    $end_dt,
+                                    [],
+                                    $range['modality']
+                                );
                                 if (is_wp_error($created)) {
                                     error_log('TutoriasBooking: handle_assign_availability - Error al crear evento: ' . $created->get_error_message());
                                     $messages[] = [

--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -94,6 +94,14 @@ class CalendarService {
         return $all_events;
     }
 
+    /**
+     * Create a calendar event.
+     *
+     * When used to define availability slots, no attendees are provided and
+     * therefore no conference link is generated even if the modality is
+     * "online". Actual appointments should include attendees so that a
+     * Google Meet link is attached automatically.
+     */
     public static function create_calendar_event($tutor_id, $summary, $description, $start_datetime, $end_datetime, $attendees=[], $modalidad = 'online') {
         global $wpdb;
         $tutor = $wpdb->get_row($wpdb->prepare("SELECT calendar_id FROM {$wpdb->prefix}tutores WHERE id = %d", $tutor_id));
@@ -115,8 +123,13 @@ class CalendarService {
             'reminders' => ['useDefault'=>false,'overrides'=>[['method'=>'email','minutes'=>60],['method'=>'popup','minutes'=>10]]],
         ];
         $options = ['sendUpdates' => 'all'];
-        if ($modalidad === 'online') {
-            $event_data['conferenceData'] = ['createRequest'=>['requestId'=>uniqid(),'conferenceSolutionKey'=>['type'=>'hangoutsMeet']]];
+        if ($modalidad === 'online' && !empty($attendees)) {
+            $event_data['conferenceData'] = [
+                'createRequest' => [
+                    'requestId' => uniqid(),
+                    'conferenceSolutionKey' => ['type' => 'hangoutsMeet']
+                ]
+            ];
             $options['conferenceDataVersion'] = 1;
         }
         $event = new \Google_Service_Calendar_Event($event_data);


### PR DESCRIPTION
## Summary
- Ensure calendar events only generate Google Meet links when modality is online and attendees are present
- Pass availability modality explicitly when creating availability slots
- Document difference between slots and real appointments in calendar service

## Testing
- `php -l includes/Google/CalendarService.php`
- `php -l includes/Admin/AdminController.php`


------
https://chatgpt.com/codex/tasks/task_e_68c13ed90fd0832f96949d3c8d0b08d6