### PR TITLE
Add booking confirmation popup before finalizing appointment

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -295,6 +295,32 @@
 }
 .tb-booking-card p { margin: 0 0 10px; }
 
+/* Modal de confirmación */
+.tb-confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.tb-confirm-content {
+  text-align: center;
+  margin-top: 0;
+}
+
+.tb-confirm-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 15px;
+}
+
 /* ---- Estilos para tarjetas/labels de franjas (modal) ---- */
 .tb-day-card {
   width: 100%;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -204,15 +204,7 @@ jQuery(document).ready(function($) {
   $('#tb_modalidad').change(loadSlots);
 
   // Envío del formulario de reserva
-  $('#tb_booking_form').submit(function(e) {
-    e.preventDefault();
-
-    var selectedSlot = $('input[name="selected_slot"]:checked');
-    if (selectedSlot.length === 0) {
-      $('#tb_response_message').html('<p class="tb-message tb-message-error">Por favor, selecciona una franja horaria.</p>').show();
-      return;
-    }
-
+  function processBooking(selectedSlot) {
       var tutor_id   = $('#tb_tutor_select').val();
       var modalidad  = $('#tb_modalidad').val();
       var dni        = $('#tb_dni_final').val();
@@ -285,5 +277,32 @@ jQuery(document).ready(function($) {
         $('#tb_submit_booking').prop('disabled', false).val('Confirmar Reserva');
       }
     });
+  }
+
+  $('#tb_booking_form').submit(function(e) {
+    e.preventDefault();
+
+    var selectedSlot = $('input[name="selected_slot"]:checked');
+    if (selectedSlot.length === 0) {
+      $('#tb_response_message').html('<p class="tb-message tb-message-error">Por favor, selecciona una franja horaria.</p>').show();
+      return;
+    }
+
+    var exam_date = selectedSlot.data('date');
+    var start_time = selectedSlot.data('start');
+    $('#tb_confirm_booking_message').text('¿Está seguro que desea reservar cita el día ' + exam_date + ' a la hora ' + start_time + '? La cita no podrá ser cancelada después de ser confirmada.');
+    $('#tb_confirm_overlay').removeClass('tb-hidden');
+
+    $('#tb_confirm_booking_yes').off('click').one('click', function() {
+      $('#tb_confirm_overlay').addClass('tb-hidden');
+      processBooking(selectedSlot);
+    });
+
+    $('#tb_confirm_booking_no').off('click').one('click', function() {
+      $('#tb_confirm_overlay').addClass('tb-hidden');
+      $('#tb_submit_booking').prop('disabled', false).val('Confirmar Reserva');
+    });
+
+    $('#tb_submit_booking').prop('disabled', true);
   });
 });

--- a/templates/frontend/booking-form.php
+++ b/templates/frontend/booking-form.php
@@ -79,5 +79,14 @@
         </div>
         <div id="tb_response_message" class="tb-message tb-hidden"></div>
     </form>
+    <div id="tb_confirm_overlay" class="tb-confirm-overlay tb-hidden">
+        <div class="tb-confirm-content tb-booking-card">
+            <p id="tb_confirm_booking_message"></p>
+            <div class="tb-confirm-buttons">
+                <button type="button" id="tb_confirm_booking_yes" class="tb-button">Confirmar</button>
+                <button type="button" id="tb_confirm_booking_no" class="tb-button">Cancelar</button>
+            </div>
+        </div>
+    </div>
     <div id="tb_booking_details_container"></div>
 </div>


### PR DESCRIPTION
## Summary
- replace inline confirmation card with popup overlay requiring explicit confirmation
- style modal and buttons to match existing booking card aesthetics
- only process bookings after popup confirmation

## Testing
- `php -l templates/frontend/booking-form.php`
- `node --check assets/js/frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68c158436e74832f86c5f79af8d7180e