### PR TITLE
Add DNI and modality filters to admin event search

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -1,12 +1,13 @@
 jQuery(function($){
     $('#tb-events-form').on('submit', function(e){
         e.preventDefault();
-        var tutor = $('#tb_events_tutor').val();
-        var user  = $('#tb_events_user').val();
-        var start = $('#tb_events_start').val();
-        var end   = $('#tb_events_end').val();
+        var tutor     = $('#tb_events_tutor').val();
+        var dni       = $('#tb_events_dni').val();
+        var modalidad = $('#tb_events_modalidad').val();
+        var start     = $('#tb_events_start').val();
+        var end       = $('#tb_events_end').val();
 
-        if(!tutor && !user && !start && !end){
+        if(!tutor && !dni && !start && !end && !modalidad){
             alert('Debe indicar al menos un filtro');
             return;
         }
@@ -15,10 +16,11 @@ jQuery(function($){
             action: 'tb_list_events',
             nonce: tbEventsData.nonce
         };
-        if(tutor) data.tutor_id = tutor;
-        if(user)  data.user_id  = user;
-        if(start) data.start_date = start;
-        if(end)   data.end_date   = end;
+        if(tutor)     data.tutor_id  = tutor;
+        if(dni)       data.dni       = dni;
+        if(modalidad) data.modalidad = modalidad;
+        if(start)     data.start_date = start;
+        if(end)       data.end_date   = end;
 
         $('#tb-events-table tbody').empty();
         $.post(ajaxurl, data, function(res){

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -42,10 +42,11 @@ class AjaxHandlers {
             wp_send_json_error('Permisos insuficientes.');
         }
         global $wpdb;
-        $tutor_id = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
-        $startRaw = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
-        $endRaw   = isset($_POST['end_date']) ? sanitize_text_field($_POST['end_date']) : '';
-        $user_q   = isset($_POST['user_id']) ? sanitize_text_field($_POST['user_id']) : '';
+        $tutor_id  = isset($_POST['tutor_id']) ? intval($_POST['tutor_id']) : 0;
+        $startRaw  = isset($_POST['start_date']) ? sanitize_text_field($_POST['start_date']) : '';
+        $endRaw    = isset($_POST['end_date']) ? sanitize_text_field($_POST['end_date']) : '';
+        $dni       = isset($_POST['dni']) ? sanitize_text_field($_POST['dni']) : '';
+        $modalidad = isset($_POST['modalidad']) ? sanitize_text_field($_POST['modalidad']) : '';
 
         $madridTz = new \DateTimeZone('Europe/Madrid');
 
@@ -80,13 +81,22 @@ class AjaxHandlers {
         $data = [];
 
         foreach ($tutor_ids as $tid) {
-            $events = CalendarService::get_busy_calendar_events($tid, $start, $end, $user_q);
+            $events = CalendarService::get_busy_calendar_events($tid, $start, $end, $dni, $modalidad);
 
             $tutor_name = $wpdb->get_var($wpdb->prepare("SELECT nombre FROM {$wpdb->prefix}tutores WHERE id=%d", $tid));
 
             foreach ($events as $ev) {
                 if (isset($ev->summary) && strtoupper(trim($ev->summary)) === 'DISPONIBLE') {
                     continue; // omitir slots de disponibilidad
+                }
+                if (!empty($modalidad)) {
+                    $desc_modalidad = '';
+                    if (!empty($ev->description) && preg_match('/Modalidad:\s*(.+)/i', $ev->description, $m)) {
+                        $desc_modalidad = strtolower(trim($m[1]));
+                    }
+                    if ($desc_modalidad !== strtolower($modalidad)) {
+                        continue;
+                    }
                 }
                 if (isset($ev->start->dateTime) && isset($ev->end->dateTime)) {
                     $startObj = new \DateTime($ev->start->dateTime);

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -150,13 +150,11 @@
                     <option value="<?php echo esc_attr($t->id); ?>"><?php echo esc_html($t->nombre); ?></option>
                 <?php endforeach; ?>
             </select>
-            <select id="tb_events_user">
-                <option value="">Todos los alumnos</option>
-                <?php foreach ($alumnos_reserva as $alumno): ?>
-                    <option value="<?php echo esc_attr($alumno->dni); ?>">
-                        <?php echo esc_html($alumno->nombre . ' ' . $alumno->apellido); ?>
-                    </option>
-                <?php endforeach; ?>
+            <input type="text" id="tb_events_dni" placeholder="DNI del alumno (opcional)">
+            <select id="tb_events_modalidad">
+                <option value="">Todos</option>
+                <option value="online">online</option>
+                <option value="presencial">presencial</option>
             </select>
             <input type="date" id="tb_events_start" placeholder="Fecha inicio (opcional)">
             <input type="date" id="tb_events_end" placeholder="Fecha fin (opcional)">


### PR DESCRIPTION
## Summary
- allow admins to filter events by DNI and modality
- send DNI and modality in events AJAX requests
- filter server-side events by selected modality

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l templates/admin/admin-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68c16923c76c832fac968d8eddb7ee99