### PR TITLE
Handle multi-day calendar events for availability

### DIFF
--- a/includes/Admin/AdminController.php
+++ b/includes/Admin/AdminController.php
@@ -194,10 +194,23 @@ class AdminController {
         $madridTz    = new \DateTimeZone('Europe/Madrid');
         $existing_dates = [];
         foreach (array_merge($events, $busy_events) as $ev) {
-            if (isset($ev->start->dateTime)) {
+            if (isset($ev->start->dateTime) && isset($ev->end->dateTime)) {
                 $start = new \DateTime($ev->start->dateTime);
                 $start->setTimezone($madridTz);
-                $existing_dates[] = $start->format('Y-m-d');
+                $end = new \DateTime($ev->end->dateTime);
+                $end->setTimezone($madridTz);
+            } elseif (isset($ev->start->date) && isset($ev->end->date)) {
+                $start = new \DateTime($ev->start->date, $madridTz);
+                $end   = new \DateTime($ev->end->date, $madridTz);
+                $end->modify('-1 day');
+            } else {
+                continue;
+            }
+
+            $current = clone $start;
+            while ($current <= $end) {
+                $existing_dates[] = $current->format('Y-m-d');
+                $current->modify('+1 day');
             }
         }
         $existing_dates = array_values(array_unique($existing_dates));
@@ -487,10 +500,23 @@ class AdminController {
             $availability_hash = md5(json_encode($events));
             $existing_dates = [];
             foreach (array_merge($events, $busy_events) as $ev) {
-                if (isset($ev->start->dateTime)) {
+                if (isset($ev->start->dateTime) && isset($ev->end->dateTime)) {
                     $start = new \DateTime($ev->start->dateTime);
                     $start->setTimezone($madridTz);
-                    $existing_dates[] = $start->format('Y-m-d');
+                    $end = new \DateTime($ev->end->dateTime);
+                    $end->setTimezone($madridTz);
+                } elseif (isset($ev->start->date) && isset($ev->end->date)) {
+                    $start = new \DateTime($ev->start->date, $madridTz);
+                    $end   = new \DateTime($ev->end->date, $madridTz);
+                    $end->modify('-1 day');
+                } else {
+                    continue;
+                }
+
+                $current = clone $start;
+                while ($current <= $end) {
+                    $existing_dates[] = $current->format('Y-m-d');
+                    $current->modify('+1 day');
                 }
             }
             $existing_dates = array_values(array_unique($existing_dates));


### PR DESCRIPTION
## Summary
- Expand existing date detection to include all days spanned by events and all-day events
- Deduplicate existing dates after collection
- Confirm JS still receives an array of YYYY-MM-DD strings to toggle view/edit menu for blocked days

## Testing
- `php -l includes/Admin/AdminController.php`
- `node --check assets/js/admin.js`

------
https://chatgpt.com/codex/tasks/task_e_68c1912910f4832f9272016e4b617960