### PR TITLE
Refina filtrado de eventos disponibles y ocupados

### DIFF
--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -81,7 +81,7 @@ class AjaxHandlers {
         $data = [];
 
         foreach ($tutor_ids as $tid) {
-            $events = CalendarService::get_busy_calendar_events($tid, $start, $end, $dni, $modalidad);
+            $events = CalendarService::get_busy_calendar_events($tid, $start, $end, $dni);
 
             $tutor_name = $wpdb->get_var($wpdb->prepare("SELECT nombre FROM {$wpdb->prefix}tutores WHERE id=%d", $tid));
 

--- a/includes/Frontend/AjaxHandlers.php
+++ b/includes/Frontend/AjaxHandlers.php
@@ -147,7 +147,7 @@ class AjaxHandlers {
 
         // Filtrar franjas que ya estén ocupadas en el calendario
         // OBTENER TODOS LOS EVENTOS QUE NO SON "DISPONIBLE". ESTOS SON LOS EVENTOS OCUPADOS/NO DISPONIBLES.
-        $busy_events = CalendarService::get_busy_calendar_events($tutor_id, $start_date_for_query, $end_date_for_query, '', $modalidad);
+        $busy_events = CalendarService::get_busy_calendar_events($tutor_id, $start_date_for_query, $end_date_for_query);
         self::debug_log('TutoriasBooking: ajax_get_available_slots() - Eventos OCUPADOS obtenidos: ' . count($busy_events) . ' eventos.');
         // self::debug_log('TutoriasBooking: busy_events: ' . print_r($busy_events, true)); // Descomentar para ver el detalle
 

--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -54,27 +54,28 @@ class CalendarService {
     public static function get_available_calendar_events($tutor_id, $start_date, $end_date, $modalidad = '') {
         $events = self::get_calendar_events($tutor_id, $start_date, $end_date);
         $available = [];
-        $target = 'DISPONIBLE';
-        if (!empty($modalidad)) {
-            $target .= ' ' . strtoupper(trim($modalidad));
-        }
+        $modalidad = strtoupper(trim($modalidad));
         foreach ($events as $event) {
-            if (isset($event->summary) && strtoupper(trim($event->summary)) === $target) {
-                $available[] = $event;
+            if (!isset($event->summary)) { continue; }
+            $summary = strtoupper(trim($event->summary));
+            if ($modalidad !== '') {
+                if ($summary === 'DISPONIBLE ' . $modalidad) {
+                    $available[] = $event;
+                }
+            } else {
+                if (strpos($summary, 'DISPONIBLE') === 0) {
+                    $available[] = $event;
+                }
             }
         }
         return $available;
     }
 
-    public static function get_busy_calendar_events($tutor_id, $start_date, $end_date, $query = '', $modalidad = '') {
+    public static function get_busy_calendar_events($tutor_id, $start_date, $end_date, $query = '') {
         $events = self::get_calendar_events($tutor_id, $start_date, $end_date, $query);
         $busy = [];
-        $target = 'DISPONIBLE';
-        if (!empty($modalidad)) {
-            $target .= ' ' . strtoupper(trim($modalidad));
-        }
         foreach ($events as $event) {
-            if (!isset($event->summary) || strtoupper(trim($event->summary)) !== $target) {
+            if (!isset($event->summary) || stripos(trim($event->summary), 'DISPONIBLE') !== 0) {
                 $busy[] = $event;
             }
         }


### PR DESCRIPTION
## Summary
- Devuelve todos los eventos "DISPONIBLE" cuando no se indica modalidad
- Marca como ocupados solo los eventos cuyo resumen no empieza por "DISPONIBLE"
- Elimina paso de modalidad en llamadas que no lo requieren

## Testing
- `php -l includes/Google/CalendarService.php`
- `php -l includes/Frontend/AjaxHandlers.php`
- `php -l includes/Admin/AjaxHandlers.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1a2fab364832f8f0d57b4c6571033