### PR TITLE
Handle availability prefixes in busy event filtering

### DIFF
--- a/includes/Google/CalendarService.php
+++ b/includes/Google/CalendarService.php
@@ -82,8 +82,19 @@ class CalendarService {
             $target .= ' ' . strtoupper(trim($modalidad));
         }
         foreach ($events as $event) {
-            if (!isset($event->summary) || strtoupper(trim($event->summary)) !== $target) {
+            if (!isset($event->summary)) {
                 $busy[] = $event;
+                continue;
+            }
+            $summary = strtoupper(trim($event->summary));
+            if (!empty($modalidad)) {
+                if ($summary !== $target) {
+                    $busy[] = $event;
+                }
+            } else {
+                if (stripos($summary, $target) !== 0) {
+                    $busy[] = $event;
+                }
             }
         }
         return $busy;


### PR DESCRIPTION
## Summary
- Ignore calendar events starting with `DISPONIBLE` when modalidad is empty
- Preserve exact matching when modalidad is provided

## Testing
- `php -l includes/Google/CalendarService.php`
- `composer validate --no-check-all`
- Simulated busy event filtering in PHP snippet

------
https://chatgpt.com/codex/tasks/task_e_68c1a679d670832fa72ab7b98458ea8d