### PR TITLE
Expose event modality in admin listings

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -30,6 +30,7 @@ jQuery(function($){
                     row += '<td>'+(ev.user||'')+'</td>';
                     row += '<td>'+(ev.tutor||'')+'</td>';
                     row += '<td>'+ev.start+' - '+ev.end+'</td>';
+                    row += '<td>'+(ev.modalidad||'')+'</td>';
                     var link = ev.url ? '<a href="'+ev.url+'" target="_blank">'+ev.url+'</a>' : '';
                     row += '<td>'+link+'</td>';
                     row += '<td><button type="button" class="tb-button tb-edit-event">Editar</button> ';

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -100,15 +100,18 @@ class AjaxHandlers {
                 if (isset($ev->summary) && strtoupper(trim($ev->summary)) === 'DISPONIBLE') {
                     continue; // omitir slots de disponibilidad
                 }
-                if (!empty($modalidad)) {
-                    $desc_modalidad = '';
-                    if (!empty($ev->description) && preg_match('/Modalidad:\s*(.+)/i', $ev->description, $m)) {
-                        $desc_modalidad = strtolower(trim($m[1]));
-                    }
-                    if ($desc_modalidad !== strtolower($modalidad)) {
-                        continue;
-                    }
+
+                $modality = '';
+                if (!empty($ev->description) && preg_match('/Modalidad:\s*(.+)/i', $ev->description, $m)) {
+                    $modality = ucfirst(strtolower(trim($m[1])));
+                } elseif (!empty($ev->summary) && preg_match('/Modalidad:\s*(.+)/i', $ev->summary, $m)) {
+                    $modality = ucfirst(strtolower(trim($m[1])));
                 }
+
+                if (!empty($modalidad) && strtolower($modality) !== strtolower($modalidad)) {
+                    continue;
+                }
+
                 if (isset($ev->start->dateTime) && isset($ev->end->dateTime)) {
                     $startObj = new \DateTime($ev->start->dateTime);
                     $startObj->setTimezone($madridTz);
@@ -116,18 +119,19 @@ class AjaxHandlers {
                     $endObj->setTimezone($madridTz);
 
                     $user_name = '';
-                    if (!empty($ev->description) && preg_match('/Nombre:\s*(.*)\n/', $ev->description, $m)) {
+                    if (!empty($ev->description) && preg_match('/Nombre:\s*(.*)\\n/', $ev->description, $m)) {
                         $user_name = trim($m[1]);
                     }
 
                     $data[] = [
-                        'id'       => $ev->id,
-                        'user'     => $user_name,
-                        'tutor'    => $tutor_name,
-                        'start'    => $startObj->format('Y-m-d H:i'),
-                        'end'      => $endObj->format('Y-m-d H:i'),
-                        'url'      => $ev->hangoutLink ?? '',
-                        'tutor_id' => $tid,
+                        'id'        => $ev->id,
+                        'user'      => $user_name,
+                        'tutor'     => $tutor_name,
+                        'start'     => $startObj->format('Y-m-d H:i'),
+                        'end'       => $endObj->format('Y-m-d H:i'),
+                        'url'       => $ev->hangoutLink ?? '',
+                        'tutor_id'  => $tid,
+                        'modalidad' => $modality,
                     ];
                 }
             }

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -163,7 +163,7 @@
 
         <table id="tb-events-table" class="tb-table">
             <thead>
-                <tr><th>Usuario</th><th>Tutor</th><th>Tramo</th><th>Cita</th><th>Acciones</th></tr>
+                <tr><th>Usuario</th><th>Tutor</th><th>Tramo</th><th>Modalidad</th><th>Cita</th><th>Acciones</th></tr>
             </thead>
             <tbody></tbody>
         </table>


### PR DESCRIPTION
## Summary
- extract event modality in `ajax_list_events` and include it in the AJAX response
- render modality column in events table and JS row builder

## Testing
- `php -l includes/Admin/AjaxHandlers.php`
- `php -l templates/admin/admin-page.php`
- `node --check assets/js/events.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1aa1451d4832f9fc8cc0b1bf81bed