### PR TITLE
Read exam date from event data

### DIFF
--- a/assets/js/admin-edit.js
+++ b/assets/js/admin-edit.js
@@ -6,9 +6,8 @@ jQuery(function($){
     var originalTutorId = row.data('tutor-id');
     var eventId = row.data('event-id');
     var selectedTutorId = originalTutorId;
-    var tramoText = row.find('td').eq(2).text();
-    var examDate = tramoText ? tramoText.split(' ')[0] : '';
-    var modalidad = row.find('td').eq(3).text().trim().toLowerCase();
+    var examDate = row.data('exam-date');
+    var modalidad = (row.data('modalidad') || '').toLowerCase();
 
     function populateTutorSelect(){
       if(!$('#tb_edit_modal').length){

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -26,7 +26,7 @@ jQuery(function($){
         $.post(ajaxurl, data, function(res){
             if(res.success){
                 res.data.forEach(function(ev){
-                    var row = '<tr data-event-id="'+ev.id+'" data-tutor-id="'+ev.tutor_id+'">';
+                    var row = '<tr data-event-id="'+ev.id+'" data-tutor-id="'+ev.tutor_id+'" data-exam-date="'+(ev.exam_date||'')+'" data-modalidad="'+(ev.modalidad||'')+'">';
                     row += '<td>'+(ev.user||'')+'</td>';
                     row += '<td>'+(ev.tutor||'')+'</td>';
                     row += '<td>'+ev.start+' - '+ev.end+'</td>';

--- a/includes/Admin/AjaxHandlers.php
+++ b/includes/Admin/AjaxHandlers.php
@@ -123,6 +123,13 @@ class AjaxHandlers {
                         $user_name = trim($m[1]);
                     }
 
+                    $exam_date = '';
+                    if (!empty($ev->description) && preg_match('/Fecha:\s*(.*)\n/i', $ev->description, $m)) {
+                        $exam_date = trim($m[1]);
+                    } elseif (!empty($ev->summary) && preg_match('/Fecha:\s*(.*)\n/i', $ev->summary, $m)) {
+                        $exam_date = trim($m[1]);
+                    }
+
                     $data[] = [
                         'id'        => $ev->id,
                         'user'      => $user_name,
@@ -132,6 +139,7 @@ class AjaxHandlers {
                         'url'       => $ev->hangoutLink ?? '',
                         'tutor_id'  => $tid,
                         'modalidad' => $modality,
+                        'exam_date' => $exam_date,
                     ];
                 }
             }


### PR DESCRIPTION
## Summary
- Parse "Fecha:" from event description and include `exam_date` in admin AJAX response
- Render admin event rows with `exam_date` and `modalidad` data attributes
- Use those row data attributes when editing events and forward `exam_date` to slot lookup

## Testing
- `node --check assets/js/events.js`
- `node --check assets/js/admin-edit.js`
- `php -l includes/Admin/AjaxHandlers.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1b8148a08832fb0641f947636a618