### PR TITLE
Hide overlay after editing events

### DIFF
--- a/assets/js/admin-edit.js
+++ b/assets/js/admin-edit.js
@@ -84,6 +84,7 @@ jQuery(function($){
 
     $('#tb_edit_cancel').off('click').on('click', function(){
       $('#tb_edit_modal').hide();
+      $('#tb_slots_overlay').hide();
     });
 
     $('#tb_edit_save').off('click').on('click', function(){
@@ -107,6 +108,7 @@ jQuery(function($){
           var linkHtml = resp.data.url ? '<a href="'+resp.data.url+'" target="_blank">'+resp.data.url+'</a>' : '';
           row.find('td').eq(4).html(linkHtml);
           $('#tb_edit_modal').hide();
+          $('#tb_slots_overlay').hide();
         } else {
           alert(resp.data || 'Error al actualizar');
         }


### PR DESCRIPTION
## Summary
- Hide background overlay when canceling event edit
- Hide background overlay after saving event changes

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c884a4dc832fb513a6264bcffe76