### PR TITLE
Sanitize event table rendering and URLs

### DIFF
--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -1,3 +1,4 @@
+
 jQuery(function($){
     $('#tb-events-form').on('submit', function(e){
         e.preventDefault();
@@ -26,19 +27,52 @@ jQuery(function($){
         $.post(ajaxurl, data, function(res){
             if(res.success){
                 res.data.forEach(function(ev){
-                    var row = '<tr data-event-id="'+ev.id+'" data-tutor-id="'+ev.tutor_id+'">';
-                    row += '<td>'+(ev.user||'')+'</td>';
-                    row += '<td>'+(ev.dni||'')+'</td>';
-                    row += '<td>'+(ev.email||'')+'</td>';
-                    row += '<td>'+(ev.tutor||'')+'</td>';
-                    row += '<td>'+ev.start+' - '+ev.end+'</td>';
-                    row += '<td>'+(ev.modalidad||'')+'</td>';
-                    var link = ev.url ? '<a href="'+ev.url+'" target="_blank">'+ev.url+'</a>' : '';
-                    row += '<td>'+link+'</td>';
-                    row += '<td><button type="button" class="tb-button tb-edit-event">Editar</button> ';
-                    row += '<button type="button" class="tb-button tb-button-danger tb-delete-event">Eliminar</button></td>';
-                    row += '</tr>';
-                    $('#tb-events-table tbody').append(row);
+                    var $row = $('<tr>')
+                        .attr('data-event-id', ev.id)
+                        .attr('data-tutor-id', ev.tutor_id);
+
+                    $row.append($('<td>').text(ev.user || ''));
+                    $row.append($('<td>').text(ev.dni || ''));
+                    $row.append($('<td>').text(ev.email || ''));
+                    $row.append($('<td>').text(ev.tutor || ''));
+                    $row.append($('<td>').text(ev.start + ' - ' + ev.end));
+                    $row.append($('<td>').text(ev.modalidad || ''));
+
+                    var $linkCell = $('<td>');
+                    if (ev.url) {
+                        var safeUrl = '';
+                        try {
+                            safeUrl = encodeURI(ev.url);
+                        } catch (e) {}
+
+                        if (/^https?:/i.test(safeUrl)) {
+                            $linkCell.append(
+                                $('<a>')
+                                    .attr('href', safeUrl)
+                                    .attr('target', '_blank')
+                                    .text(safeUrl)
+                            );
+                        }
+                    }
+                    $row.append($linkCell);
+
+                    var $actions = $('<td>');
+                    $actions.append(
+                        $('<button>')
+                            .attr('type', 'button')
+                            .addClass('tb-button tb-edit-event')
+                            .text('Editar')
+                    );
+                    $actions.append(' ');
+                    $actions.append(
+                        $('<button>')
+                            .attr('type', 'button')
+                            .addClass('tb-button tb-button-danger tb-delete-event')
+                            .text('Eliminar')
+                    );
+                    $row.append($actions);
+
+                    $('#tb-events-table tbody').append($row);
                 });
             } else {
                 alert(res.data || 'Error al obtener eventos');


### PR DESCRIPTION
## Summary
- build event list rows with jQuery elements instead of string concatenation
- encode and validate event URLs before linking to avoid HTML injection

## Testing
- ⚠️ `npm test` (missing package.json)
- ✅ `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68c7bb9ba0f0832fb9aca66473ea6f12