### PR TITLE
Replace admin alerts with dismissible notices

### DIFF
--- a/assets/js/admin-edit.js
+++ b/assets/js/admin-edit.js
@@ -72,8 +72,8 @@ jQuery(function($){
           };
 
           tbCalendarUtils.renderCalendar(window.currentMonthDate);
-        } else {
-          alert(res.data || 'Error al obtener disponibilidad');
+        } else if (window.tbAdminNotices) {
+          window.tbAdminNotices.showError(res.data || 'Error al obtener disponibilidad');
         }
       });
     }
@@ -110,9 +110,12 @@ jQuery(function($){
           row.find('td').eq(6).html(linkHtml);
           $('#tb_edit_modal').hide();
           $('#tb_slots_overlay').hide();
+          if (window.tbAdminNotices) {
+            window.tbAdminNotices.showSuccess('La cita se actualizó correctamente.');
+          }
 
-        } else {
-          alert(resp.data || 'Error al actualizar');
+        } else if (window.tbAdminNotices) {
+          window.tbAdminNotices.showError(resp.data || 'Error al actualizar');
         }
       });
     });

--- a/assets/js/admin-notices.js
+++ b/assets/js/admin-notices.js
@@ -1,0 +1,110 @@
+(function($, window){
+    'use strict';
+
+    if (!window) {
+        return;
+    }
+
+    var noticeContainerClass = 'tb-dynamic-notices';
+
+    function getAdminWrapper() {
+        var $wrapper = $('.tb-admin-wrapper').first();
+        if (!$wrapper.length) {
+            $wrapper = $('#wpbody-content').length ? $('#wpbody-content') : $('body');
+        }
+        return $wrapper;
+    }
+
+    function ensureNoticeContainer() {
+        var $wrapper = getAdminWrapper();
+        var selector = '.' + noticeContainerClass;
+        var $container = $wrapper.children(selector).first();
+        if (!$container.length) {
+            $container = $('<div>').addClass(noticeContainerClass);
+            var $existing = $wrapper.children('.tb-notice:last');
+            if ($existing.length) {
+                $container.insertAfter($existing);
+            } else {
+                $wrapper.prepend($container);
+            }
+        }
+        return $container;
+    }
+
+    function appendMessage($target, message) {
+        if (Array.isArray(message)) {
+            message.forEach(function(line, index){
+                if (index > 0) {
+                    $target.append('<br>');
+                }
+                $target.append(document.createTextNode(line != null ? String(line) : ''));
+            });
+            return;
+        }
+        var text = message == null ? '' : String(message);
+        var parts = text.split(/\r?\n/);
+        parts.forEach(function(part, idx){
+            if (idx > 0) {
+                $target.append('<br>');
+            }
+            $target.append(document.createTextNode(part));
+        });
+    }
+
+    function createNotice(type, message) {
+        var classes = ['notice', 'is-dismissible', 'tb-notice'];
+        classes.push(type === 'success' ? 'notice-success' : 'notice-error');
+        var $notice = $('<div>').addClass(classes.join(' '));
+        var $message = $('<p>');
+        appendMessage($message, message);
+        var $button = $('<button type="button" class="notice-dismiss"><span class="screen-reader-text"></span></button>');
+        $button.find('.screen-reader-text').text('Cerrar este aviso.');
+        $notice.append($message).append($button);
+        $notice.on('click', '.notice-dismiss', function(){
+            $notice.fadeOut(200, function(){
+                $notice.remove();
+            });
+        });
+        return $notice;
+    }
+
+    function addNotice(type, message) {
+        var text = message;
+        if (text == null) {
+            return;
+        }
+        if (Array.isArray(text) && !text.length) {
+            return;
+        }
+        if (!Array.isArray(text)) {
+            text = String(text);
+            if (!text.trim()) {
+                return;
+            }
+        }
+        var $container = ensureNoticeContainer();
+        var $notice = createNotice(type, message);
+        $container.append($notice);
+        return $notice;
+    }
+
+    function clearNotices() {
+        var $container = $('.' + noticeContainerClass);
+        if ($container.length) {
+            $container.empty();
+        }
+    }
+
+    window.tbAdminNotices = {
+        showSuccess: function(message){
+            return addNotice('success', message);
+        },
+        showError: function(message){
+            return addNotice('error', message);
+        },
+        clear: function(){
+            clearNotices();
+        }
+    };
+
+})(jQuery, window);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -194,14 +194,17 @@ jQuery(function($){
         }
         var date = $(this).parent().data('date');
         $.post(ajaxurl, {action: 'tb_get_day_availability', tutor_id: window.tbTutorId, date: date, nonce: tbAdminData.ajax_nonce}, function(res){
+            if (!window.tbAdminNotices) {
+                return;
+            }
             if (res.success) {
                 if (res.data && res.data.length) {
-                    alert(res.data.join('\n'));
+                    window.tbAdminNotices.showSuccess(res.data);
                 } else {
-                    alert('No hay disponibilidad para este día');
+                    window.tbAdminNotices.showError('No hay disponibilidad para este día');
                 }
             } else {
-                alert(res.data || 'Error al obtener la disponibilidad');
+                window.tbAdminNotices.showError(res.data || 'Error al obtener la disponibilidad');
             }
         });
     });
@@ -267,7 +270,9 @@ jQuery(function($){
         }
         if (!valid) {
             e.preventDefault();
-            alert('Los rangos de tiempo son inválidos o se solapan.');
+            if (window.tbAdminNotices) {
+                window.tbAdminNotices.showError('Los rangos de tiempo son inválidos o se solapan.');
+            }
         } else if (window.tbEditingDate && ranges.length === 0) {
             if (!confirm('Se eliminará la disponibilidad existente para este día. ¿Desea continuar?')) {
                 e.preventDefault();

--- a/assets/js/events.js
+++ b/assets/js/events.js
@@ -10,7 +10,9 @@ jQuery(function($){
         var end       = $('#tb_events_end').val();
 
         if(!tutor && !student && !start && !end && !modalidad){
-            alert('Debe indicar al menos un filtro');
+            if (window.tbAdminNotices) {
+                window.tbAdminNotices.showError('Debe indicar al menos un filtro');
+            }
             return;
         }
 
@@ -75,8 +77,8 @@ jQuery(function($){
 
                     $('#tb-events-table tbody').append($row);
                 });
-            } else {
-                alert(res.data || 'Error al obtener eventos');
+            } else if (window.tbAdminNotices) {
+                window.tbAdminNotices.showError(res.data || 'Error al obtener eventos');
             }
         });
     });
@@ -91,7 +93,9 @@ jQuery(function($){
         var end       = $('#tb_events_end').val();
 
         if(!tutor && !student && !start && !end && !modalidad){
-            alert('Debe indicar al menos un filtro');
+            if (window.tbAdminNotices) {
+                window.tbAdminNotices.showError('Debe indicar al menos un filtro');
+            }
             return;
         }
 
@@ -121,8 +125,11 @@ jQuery(function($){
         }, function(res){
             if(res.success){
                 row.remove();
-            } else {
-                alert(res.data || 'Error al eliminar');
+                if (window.tbAdminNotices) {
+                    window.tbAdminNotices.showSuccess('La cita se eliminó correctamente.');
+                }
+            } else if (window.tbAdminNotices) {
+                window.tbAdminNotices.showError(res.data || 'Error al eliminar');
             }
         });
     });

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -50,6 +50,7 @@ class AdminMenu {
         }
         $admin_css    = TB_PLUGIN_DIR . 'assets/css/admin.css';
         $frontend_css = TB_PLUGIN_DIR . 'assets/css/frontend.css';
+        $notices_js   = TB_PLUGIN_DIR . 'assets/js/admin-notices.js';
         $admin_js     = TB_PLUGIN_DIR . 'assets/js/admin.js';
         $events_js    = TB_PLUGIN_DIR . 'assets/js/events.js';
         $utils_js     = TB_PLUGIN_DIR . 'assets/js/calendar-utils.js';
@@ -70,9 +71,17 @@ class AdminMenu {
         );
 
         wp_enqueue_script(
+            'tb-admin-notices',
+            TB_PLUGIN_URL . 'assets/js/admin-notices.js',
+            ['jquery'],
+            file_exists($notices_js) ? filemtime($notices_js) : false,
+            true
+        );
+
+        wp_enqueue_script(
             'tb-admin',
             TB_PLUGIN_URL . 'assets/js/admin.js',
-            ['jquery'],
+            ['jquery', 'tb-admin-notices'],
             file_exists($admin_js) ? filemtime($admin_js) : false,
             true
         );
@@ -97,7 +106,7 @@ class AdminMenu {
         wp_enqueue_script(
             'tb-events',
             TB_PLUGIN_URL . 'assets/js/events.js',
-            ['jquery','tb-calendar-utils'],
+            ['jquery','tb-calendar-utils','tb-admin-notices'],
             file_exists($events_js) ? filemtime($events_js) : false,
             true
         );
@@ -113,7 +122,7 @@ class AdminMenu {
         wp_enqueue_script(
             'tb-admin-edit',
             TB_PLUGIN_URL . 'assets/js/admin-edit.js',
-            ['jquery','tb-calendar-utils'],
+            ['jquery','tb-calendar-utils','tb-admin-notices'],
             file_exists($edit_js) ? filemtime($edit_js) : false,
             true
         );


### PR DESCRIPTION
## Summary
- add a reusable `tbAdminNotices` helper that renders dismissible WordPress-style admin notices
- update admin event management scripts to surface success and error messages through the notice helper instead of browser alerts
- enqueue the notice helper for all tutorías admin pages so dynamic messages share the panel styling

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c94cd3735c832fa0e92076c14d5442