### PR TITLE
Integrate WP_List_Table for admin lists

### DIFF
--- a/includes/Admin/AlumnosListTable.php
+++ b/includes/Admin/AlumnosListTable.php
@@ -1,0 +1,302 @@
+<?php
+namespace TutoriasBooking\Admin;
+
+use function __;
+use function absint;
+use function add_query_arg;
+use function admin_url;
+use function esc_attr;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function esc_js;
+use function esc_url;
+use function sanitize_email;
+use function sanitize_text_field;
+use function sprintf;
+use function strtoupper;
+use function wp_nonce_field;
+use function wp_nonce_url;
+use function wp_unslash;
+use function wp_verify_nonce;
+use function _n;
+
+if (!class_exists('WP_List_Table')) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class AlumnosListTable extends \WP_List_Table {
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    protected $items = [];
+
+    /**
+     * @var array<int, array{type:string,text:string}>
+     */
+    private $messages = [];
+
+    /**
+     * @var string
+     */
+    private $table_name;
+
+    public function __construct(string $table_name) {
+        $this->table_name = $table_name;
+
+        parent::__construct([
+            'singular' => 'alumno',
+            'plural'   => 'alumnos',
+            'ajax'     => false,
+        ]);
+    }
+
+    public function prepare_items(): void {
+        $this->process_bulk_action();
+
+        $columns  = $this->get_columns();
+        $hidden   = [];
+        $sortable = $this->get_sortable_columns();
+        $this->_column_headers = [$columns, $hidden, $sortable, 'dni'];
+
+        $per_page     = $this->get_items_per_page('tb_alumnos_per_page', 20);
+        $current_page = $this->get_pagenum();
+        $search       = isset($_REQUEST['s']) ? sanitize_text_field(wp_unslash($_REQUEST['s'])) : '';
+        $orderby      = isset($_REQUEST['orderby']) ? sanitize_text_field(wp_unslash($_REQUEST['orderby'])) : 'id';
+        $order        = isset($_REQUEST['order']) ? strtoupper(sanitize_text_field(wp_unslash($_REQUEST['order']))) : 'ASC';
+
+        $allowed_orderby = ['id', 'dni', 'nombre', 'apellido', 'email', 'online', 'presencial'];
+        if (!in_array($orderby, $allowed_orderby, true)) {
+            $orderby = 'id';
+        }
+        if (!in_array($order, ['ASC', 'DESC'], true)) {
+            $order = 'ASC';
+        }
+
+        global $wpdb;
+
+        $where_clauses = [];
+        $prepare_args  = [];
+
+        if ($search !== '') {
+            $like            = '%' . $wpdb->esc_like($search) . '%';
+            $where_clauses[] = '(dni LIKE %s OR nombre LIKE %s OR apellido LIKE %s OR email LIKE %s)';
+            $prepare_args[]  = $like;
+            $prepare_args[]  = $like;
+            $prepare_args[]  = $like;
+            $prepare_args[]  = $like;
+        }
+
+        $where_sql = '';
+        if (!empty($where_clauses)) {
+            $where_sql = ' WHERE ' . implode(' AND ', $where_clauses);
+        }
+
+        $count_query = "SELECT COUNT(*) FROM {$this->table_name}{$where_sql}";
+        if (!empty($prepare_args)) {
+            $total_items = (int) $wpdb->get_var($wpdb->prepare($count_query, $prepare_args));
+        } else {
+            $total_items = (int) $wpdb->get_var($count_query);
+        }
+
+        $data_query   = "SELECT id, dni, nombre, apellido, email, online, presencial FROM {$this->table_name}{$where_sql} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+        $data_args    = $prepare_args;
+        $data_args[]  = $per_page;
+        $data_args[]  = ($current_page - 1) * $per_page;
+        $prepared_sql = $wpdb->prepare($data_query, $data_args);
+        $results      = $wpdb->get_results($prepared_sql, ARRAY_A);
+
+        $items = [];
+        if (is_array($results)) {
+            foreach ($results as $row) {
+                $items[] = $this->sanitize_item($row);
+            }
+        }
+
+        $this->items = $items;
+
+        $this->set_pagination_args([
+            'total_items' => $total_items,
+            'per_page'    => $per_page,
+            'total_pages' => $per_page > 0 ? (int) ceil($total_items / $per_page) : 0,
+        ]);
+    }
+
+    public function get_columns(): array {
+        return [
+            'cb'         => '<input type="checkbox" />',
+            'id'         => __('ID', 'tutorias-booking'),
+            'dni'        => __('DNI', 'tutorias-booking'),
+            'nombre'     => __('Nombre', 'tutorias-booking'),
+            'apellido'   => __('Apellido', 'tutorias-booking'),
+            'email'      => __('Email', 'tutorias-booking'),
+            'online'     => __('Online', 'tutorias-booking'),
+            'presencial' => __('Presencial', 'tutorias-booking'),
+            'acciones'   => __('Acciones', 'tutorias-booking'),
+        ];
+    }
+
+    protected function get_sortable_columns(): array {
+        return [
+            'id'       => ['id', true],
+            'dni'      => ['dni', false],
+            'nombre'   => ['nombre', false],
+            'apellido' => ['apellido', false],
+            'email'    => ['email', false],
+        ];
+    }
+
+    protected function column_cb($item): string {
+        return sprintf('<input type="checkbox" name="alumno[]" value="%d" />', $item['id']);
+    }
+
+    protected function column_dni($item): string {
+        $alumno_id = (int) $item['id'];
+
+        $delete_url = wp_nonce_url(
+            add_query_arg([
+                'page'   => 'tb-alumnos',
+                'action' => 'delete',
+                'alumno' => $alumno_id,
+            ], admin_url('admin.php')),
+            'tb_delete_alumno_' . $alumno_id
+        );
+
+        $actions = [
+            'delete' => sprintf('<a href="%s" onclick="return confirm(\'%s\');">%s</a>', esc_url($delete_url), esc_js(__('¿Eliminar este alumno?', 'tutorias-booking')), esc_html__('Eliminar', 'tutorias-booking')),
+        ];
+
+        return sprintf('<strong>%s</strong>%s', esc_html($item['dni']), $this->row_actions($actions));
+    }
+
+    protected function column_online($item): string {
+        $alumno_id = (int) $item['id'];
+        $checked   = !empty($item['online']) ? 'checked' : '';
+        $label     = sprintf(
+            __('Estado online para %s %s', 'tutorias-booking'),
+            $item['nombre'],
+            $item['apellido']
+        );
+
+        return sprintf(
+            '<label class="screen-reader-text" for="tb_online_%1$d">%2$s</label><input type="checkbox" id="tb_online_%1$d" name="tb_online" value="1" form="tb_update_%1$d" %3$s />',
+            $alumno_id,
+            esc_html($label),
+            $checked
+        );
+    }
+
+    protected function column_presencial($item): string {
+        $alumno_id = (int) $item['id'];
+        $checked   = !empty($item['presencial']) ? 'checked' : '';
+        $label     = sprintf(
+            __('Estado presencial para %s %s', 'tutorias-booking'),
+            $item['nombre'],
+            $item['apellido']
+        );
+
+        return sprintf(
+            '<label class="screen-reader-text" for="tb_presencial_%1$d">%2$s</label><input type="checkbox" id="tb_presencial_%1$d" name="tb_presencial" value="1" form="tb_update_%1$d" %3$s />',
+            $alumno_id,
+            esc_html($label),
+            $checked
+        );
+    }
+
+    protected function column_acciones($item): string {
+        $alumno_id = (int) $item['id'];
+
+        $update_form  = '<form method="POST" id="tb_update_' . esc_attr((string) $alumno_id) . '" class="tb-inline-form">';
+        $update_form .= wp_nonce_field('tb_admin_action', 'tb_admin_nonce', true, false);
+        $update_form .= '<input type="hidden" name="tb_update_alumno_id" value="' . esc_attr((string) $alumno_id) . '" />';
+        $update_form .= '<button type="submit" class="tb-button">' . esc_html__('Actualizar', 'tutorias-booking') . '</button>';
+        $update_form .= '</form>';
+
+        return $update_form;
+    }
+
+    public function column_default($item, $column_name): string {
+        if (isset($item[$column_name])) {
+            return esc_html((string) $item[$column_name]);
+        }
+
+        return '';
+    }
+
+    protected function get_bulk_actions(): array {
+        return [
+            'delete' => esc_html__('Eliminar', 'tutorias-booking'),
+        ];
+    }
+
+    public function no_items(): void {
+        esc_html_e('No hay alumnos registrados.', 'tutorias-booking');
+    }
+
+    public function get_messages(): array {
+        return $this->messages;
+    }
+
+    protected function process_bulk_action(): void {
+        $action = $this->current_action();
+        if ('delete' !== $action) {
+            return;
+        }
+
+        $ids = [];
+        if (isset($_REQUEST['alumno'])) {
+            $raw_ids = $_REQUEST['alumno'];
+            if (!is_array($raw_ids)) {
+                $raw_ids = [$raw_ids];
+            }
+            foreach ($raw_ids as $id) {
+                $ids[] = absint($id);
+            }
+        }
+
+        $ids = array_values(array_filter($ids));
+        if (empty($ids)) {
+            return;
+        }
+
+        $nonce = isset($_REQUEST['_wpnonce']) ? sanitize_text_field(wp_unslash($_REQUEST['_wpnonce'])) : '';
+        $nonce_action = count($ids) > 1 ? 'bulk-' . $this->_args['plural'] : 'tb_delete_alumno_' . $ids[0];
+        if (!wp_verify_nonce($nonce, $nonce_action)) {
+            $this->messages[] = [
+                'type' => 'error',
+                'text' => __('No se pudo verificar la petición para eliminar alumnos.', 'tutorias-booking'),
+            ];
+            return;
+        }
+
+        global $wpdb;
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $delete_sql   = "DELETE FROM {$this->table_name} WHERE id IN ($placeholders)";
+        $result       = $wpdb->query($wpdb->prepare($delete_sql, $ids));
+
+        if ($result === false) {
+            $this->messages[] = [
+                'type' => 'error',
+                'text' => __('Ocurrió un error al eliminar los alumnos seleccionados.', 'tutorias-booking'),
+            ];
+        } else {
+            $count = (int) $result;
+            $this->messages[] = [
+                'type' => 'success',
+                'text' => sprintf(_n('%d alumno eliminado.', '%d alumnos eliminados.', $count, 'tutorias-booking'), $count),
+            ];
+        }
+    }
+
+    private function sanitize_item(array $row): array {
+        return [
+            'id'         => isset($row['id']) ? absint($row['id']) : 0,
+            'dni'        => isset($row['dni']) ? sanitize_text_field($row['dni']) : '',
+            'nombre'     => isset($row['nombre']) ? sanitize_text_field($row['nombre']) : '',
+            'apellido'   => isset($row['apellido']) ? sanitize_text_field($row['apellido']) : '',
+            'email'      => isset($row['email']) ? sanitize_email($row['email']) : '',
+            'online'     => !empty($row['online']) ? 1 : 0,
+            'presencial' => !empty($row['presencial']) ? 1 : 0,
+        ];
+    }
+}

--- a/includes/Admin/TutorsListTable.php
+++ b/includes/Admin/TutorsListTable.php
@@ -1,0 +1,276 @@
+<?php
+namespace TutoriasBooking\Admin;
+
+use function __;
+use function absint;
+use function add_query_arg;
+use function admin_url;
+use function esc_html;
+use function esc_html__;
+use function esc_html_e;
+use function esc_js;
+use function esc_url;
+use function sanitize_email;
+use function sanitize_text_field;
+use function sprintf;
+use function strtoupper;
+use function wp_nonce_url;
+use function wp_unslash;
+use function wp_verify_nonce;
+use function _n;
+
+if (!class_exists('WP_List_Table')) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class TutorsListTable extends \WP_List_Table {
+    /**
+     * @var array<int, array<string, mixed>>
+     */
+    protected $items = [];
+
+    /**
+     * @var array<int, array{type:string,text:string}>
+     */
+    private $messages = [];
+
+    public function __construct() {
+        parent::__construct([
+            'singular' => 'tutor',
+            'plural'   => 'tutores',
+            'ajax'     => false,
+        ]);
+    }
+
+    /**
+     * Prepare table items, process actions, and setup pagination.
+     */
+    public function prepare_items(): void {
+        $this->process_bulk_action();
+
+        $columns  = $this->get_columns();
+        $hidden   = [];
+        $sortable = $this->get_sortable_columns();
+        $this->_column_headers = [$columns, $hidden, $sortable, 'nombre'];
+
+        $per_page     = $this->get_items_per_page('tb_tutores_per_page', 20);
+        $current_page = $this->get_pagenum();
+        $search       = isset($_REQUEST['s']) ? sanitize_text_field(wp_unslash($_REQUEST['s'])) : '';
+        $orderby      = isset($_REQUEST['orderby']) ? sanitize_text_field(wp_unslash($_REQUEST['orderby'])) : 'nombre';
+        $order        = isset($_REQUEST['order']) ? strtoupper(sanitize_text_field(wp_unslash($_REQUEST['order']))) : 'ASC';
+
+        $allowed_orderby = ['nombre', 'email'];
+        if (!in_array($orderby, $allowed_orderby, true)) {
+            $orderby = 'nombre';
+        }
+        if (!in_array($order, ['ASC', 'DESC'], true)) {
+            $order = 'ASC';
+        }
+
+        global $wpdb;
+        $table = $wpdb->prefix . 'tutores';
+
+        $where_clauses = [];
+        $prepare_args  = [];
+
+        if ($search !== '') {
+            $like            = '%' . $wpdb->esc_like($search) . '%';
+            $where_clauses[] = '(nombre LIKE %s OR email LIKE %s)';
+            $prepare_args[]  = $like;
+            $prepare_args[]  = $like;
+        }
+
+        $where_sql = '';
+        if (!empty($where_clauses)) {
+            $where_sql = ' WHERE ' . implode(' AND ', $where_clauses);
+        }
+
+        $count_query = "SELECT COUNT(*) FROM {$table}{$where_sql}";
+        if (!empty($prepare_args)) {
+            $total_items = (int) $wpdb->get_var($wpdb->prepare($count_query, $prepare_args));
+        } else {
+            $total_items = (int) $wpdb->get_var($count_query);
+        }
+
+        $data_query   = "SELECT id, nombre, email FROM {$table}{$where_sql} ORDER BY {$orderby} {$order} LIMIT %d OFFSET %d";
+        $data_args    = $prepare_args;
+        $data_args[]  = $per_page;
+        $data_args[]  = ($current_page - 1) * $per_page;
+        $prepared_sql = $wpdb->prepare($data_query, $data_args);
+        $results      = $wpdb->get_results($prepared_sql, ARRAY_A);
+
+        $tokens_rows = $wpdb->get_col("SELECT DISTINCT tutor_id FROM {$wpdb->prefix}tutores_tokens");
+        $tokens      = [];
+        if (is_array($tokens_rows)) {
+            foreach ($tokens_rows as $token_id) {
+                $tokens[(int) $token_id] = true;
+            }
+        }
+
+        $items = [];
+        if (is_array($results)) {
+            foreach ($results as $row) {
+                $item = $this->sanitize_item($row);
+                $has_token = !empty($tokens[$item['id']]);
+                $item['estado']       = $has_token;
+                $item['estado_label'] = $has_token ? '✅ Conectado' : '❌ No conectado';
+                $items[] = $item;
+            }
+        }
+
+        $this->items = $items;
+
+        $this->set_pagination_args([
+            'total_items' => $total_items,
+            'per_page'    => $per_page,
+            'total_pages' => $per_page > 0 ? (int) ceil($total_items / $per_page) : 0,
+        ]);
+    }
+
+    public function get_columns(): array {
+        return [
+            'cb'     => '<input type="checkbox" />',
+            'nombre' => __('Nombre', 'tutorias-booking'),
+            'email'  => __('Email', 'tutorias-booking'),
+            'estado' => __('Estado', 'tutorias-booking'),
+        ];
+    }
+
+    protected function get_sortable_columns(): array {
+        return [
+            'nombre' => ['nombre', true],
+            'email'  => ['email', false],
+        ];
+    }
+
+    protected function column_cb($item): string {
+        return sprintf('<input type="checkbox" name="tutor[]" value="%d" />', $item['id']);
+    }
+
+    protected function column_nombre($item): string {
+        $tutor_id = (int) $item['id'];
+
+        $connect_url = add_query_arg([
+            'page'     => 'tb-tutores',
+            'action'   => 'tb_auth_google',
+            'tutor_id' => $tutor_id,
+        ], admin_url('admin.php'));
+
+        $availability_url = add_query_arg([
+            'page'     => 'tb-tutores',
+            'action'   => 'tb_assign_availability',
+            'tutor_id' => $tutor_id,
+        ], admin_url('admin.php'));
+
+        $delete_url = wp_nonce_url(
+            add_query_arg([
+                'page'   => 'tb-tutores',
+                'action' => 'delete',
+                'tutor'  => $tutor_id,
+            ], admin_url('admin.php')),
+            'tb_delete_tutor_' . $tutor_id
+        );
+
+        $actions = [
+            'connect'       => sprintf('<a href="%s">%s</a>', esc_url($connect_url), esc_html__('Conectar Calendar', 'tutorias-booking')),
+            'availability'  => sprintf('<a href="%s">%s</a>', esc_url($availability_url), esc_html__('Asignar Disponibilidad', 'tutorias-booking')),
+            'delete'        => sprintf('<a href="%s" onclick="return confirm(\'%s\');">%s</a>', esc_url($delete_url), esc_js(__('¿Eliminar este tutor?', 'tutorias-booking')), esc_html__('Eliminar', 'tutorias-booking')),
+        ];
+
+        return sprintf('<strong>%s</strong>%s', esc_html($item['nombre']), $this->row_actions($actions));
+    }
+
+    protected function column_email($item): string {
+        return sprintf('<a href="mailto:%1$s">%1$s</a>', esc_html($item['email']));
+    }
+
+    protected function column_estado($item): string {
+        return esc_html($item['estado_label']);
+    }
+
+    public function column_default($item, $column_name): string {
+        if (isset($item[$column_name])) {
+            return esc_html((string) $item[$column_name]);
+        }
+
+        return '';
+    }
+
+    protected function get_bulk_actions(): array {
+        return [
+            'delete' => esc_html__('Eliminar', 'tutorias-booking'),
+        ];
+    }
+
+    public function no_items(): void {
+        esc_html_e('No hay tutores registrados.', 'tutorias-booking');
+    }
+
+    public function get_messages(): array {
+        return $this->messages;
+    }
+
+    protected function process_bulk_action(): void {
+        $action = $this->current_action();
+        if ('delete' !== $action) {
+            return;
+        }
+
+        $ids = [];
+        if (isset($_REQUEST['tutor'])) {
+            $raw_ids = $_REQUEST['tutor'];
+            if (!is_array($raw_ids)) {
+                $raw_ids = [$raw_ids];
+            }
+            foreach ($raw_ids as $id) {
+                $ids[] = absint($id);
+            }
+        }
+
+        $ids = array_values(array_filter($ids));
+        if (empty($ids)) {
+            return;
+        }
+
+        $nonce = isset($_REQUEST['_wpnonce']) ? sanitize_text_field(wp_unslash($_REQUEST['_wpnonce'])) : '';
+        $nonce_action = count($ids) > 1 ? 'bulk-' . $this->_args['plural'] : 'tb_delete_tutor_' . $ids[0];
+        if (!wp_verify_nonce($nonce, $nonce_action)) {
+            $this->messages[] = [
+                'type' => 'error',
+                'text' => __('No se pudo verificar la petición para eliminar tutores.', 'tutorias-booking'),
+            ];
+            return;
+        }
+
+        global $wpdb;
+        $table       = $wpdb->prefix . 'tutores';
+        $tokens_table = $wpdb->prefix . 'tutores_tokens';
+
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $delete_sql   = "DELETE FROM {$table} WHERE id IN ($placeholders)";
+        $result       = $wpdb->query($wpdb->prepare($delete_sql, $ids));
+
+        $wpdb->query($wpdb->prepare("DELETE FROM {$tokens_table} WHERE tutor_id IN ($placeholders)", $ids));
+
+        if ($result === false) {
+            $this->messages[] = [
+                'type' => 'error',
+                'text' => __('Ocurrió un error al eliminar los tutores seleccionados.', 'tutorias-booking'),
+            ];
+        } else {
+            $count = (int) $result;
+            $this->messages[] = [
+                'type' => 'success',
+                'text' => sprintf(_n('%d tutor eliminado.', '%d tutores eliminados.', $count, 'tutorias-booking'), $count),
+            ];
+        }
+    }
+
+    private function sanitize_item(array $row): array {
+        return [
+            'id'     => isset($row['id']) ? absint($row['id']) : 0,
+            'nombre' => isset($row['nombre']) ? sanitize_text_field($row['nombre']) : '',
+            'email'  => isset($row['email']) ? sanitize_email($row['email']) : '',
+        ];
+    }
+}

--- a/includes/Core/Loader.php
+++ b/includes/Core/Loader.php
@@ -5,6 +5,8 @@ class Loader {
     public static function init() {
         require_once TB_PLUGIN_DIR . 'includes/Admin/AdminMenu.php';
         require_once TB_PLUGIN_DIR . 'includes/Admin/AdminPage.php';
+        require_once TB_PLUGIN_DIR . 'includes/Admin/TutorsListTable.php';
+        require_once TB_PLUGIN_DIR . 'includes/Admin/AlumnosListTable.php';
         require_once TB_PLUGIN_DIR . 'includes/Admin/AdminController.php';
         require_once TB_PLUGIN_DIR . 'includes/Admin/AjaxHandlers.php';
         require_once TB_PLUGIN_DIR . 'includes/Frontend/Shortcodes.php';

--- a/templates/admin/alumnos.php
+++ b/templates/admin/alumnos.php
@@ -57,75 +57,19 @@
         <h2 class="tb-subtitle">Alumnos en la Tabla de Reserva</h2>
 
         <?php if ($table_exists): ?>
-            <form method="GET" class="tb-form">
-                <input type="hidden" name="page" value="tb-alumnos">
-                <div class="tb-form-field">
-                    <label for="tb_search_student">Buscar alumno (DNI o nombre)</label>
-                    <input type="text" id="tb_search_student" name="tb_search_student" placeholder="Buscar por DNI o Nombre" value="<?php echo esc_attr($search_student); ?>">
-                </div>
-                <button type="submit" class="tb-button">Buscar</button>
-                <?php if (!empty($search_student)): ?>
-                    <a href="<?php echo esc_url(admin_url('admin.php?page=tb-alumnos')); ?>" class="tb-button">Limpiar</a>
-                <?php endif; ?>
-            </form>
-
-            <?php if (!empty($alumnos_reserva)): ?>
-                <table class="tb-table">
-                    <thead>
-                        <tr><th>ID</th><th>DNI</th><th>Nombre</th><th>Apellido</th><th>Email</th><th>Online</th><th>Presencial</th><th>Acciones</th></tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($alumnos_reserva as $alumno): ?>
-                            <?php $alumno_id = isset($alumno['id']) ? absint($alumno['id']) : 0; ?>
-                            <tr>
-                                <td><?php echo esc_html($alumno_id); ?></td>
-                                <td><?php echo esc_html($alumno['dni']); ?></td>
-                                <td><?php echo esc_html($alumno['nombre']); ?></td>
-                                <td><?php echo esc_html($alumno['apellido']); ?></td>
-                                <td><?php echo esc_html($alumno['email']); ?></td>
-                                <td>
-                                    <label class="screen-reader-text" for="tb_online_<?php echo esc_attr($alumno_id); ?>">
-                                        <?php echo esc_html(sprintf('Estado online para %s %s', $alumno['nombre'], $alumno['apellido'])); ?>
-                                    </label>
-                                    <input type="checkbox" id="tb_online_<?php echo esc_attr($alumno_id); ?>" name="tb_online" value="1" form="tb_update_<?php echo esc_attr($alumno_id); ?>" <?php checked($alumno['online']); ?>>
-                                </td>
-                                <td>
-                                    <label class="screen-reader-text" for="tb_presencial_<?php echo esc_attr($alumno_id); ?>">
-                                        <?php echo esc_html(sprintf('Estado presencial para %s %s', $alumno['nombre'], $alumno['apellido'])); ?>
-                                    </label>
-                                    <input type="checkbox" id="tb_presencial_<?php echo esc_attr($alumno_id); ?>" name="tb_presencial" value="1" form="tb_update_<?php echo esc_attr($alumno_id); ?>" <?php checked($alumno['presencial']); ?>>
-                                </td>
-                                <td>
-                                    <form method="POST" id="tb_update_<?php echo esc_attr($alumno_id); ?>" class="tb-inline-form">
-                                        <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                        <input type="hidden" name="tb_update_alumno_id" value="<?php echo esc_attr($alumno_id); ?>">
-                                        <button type="submit" class="tb-button">Actualizar</button>
-                                    </form>
-                                    <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este alumno?');">
-                                        <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                        <input type="hidden" name="tb_delete_alumno_id" value="<?php echo esc_attr($alumno_id); ?>">
-                                        <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
-                                    </form>
-                                </td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-
-                <?php if (empty($search_student) && $total_pages > 1): ?>
-                    <div class="tb-pagination">
-                        <?php for ($i = 1; $i <= $total_pages; $i++): ?>
-                            <a class="tb-button <?php echo ($i === $current_page) ? 'active' : ''; ?>" href="<?php echo esc_url('admin.php?page=tb-alumnos&tb_page=' . $i); ?>"><?php echo esc_html($i); ?></a>
-                        <?php endfor; ?>
-                    </div>
-                <?php endif; ?>
+            <?php if (isset($alumnos_table)): ?>
+                <form method="post">
+                    <input type="hidden" name="page" value="<?php echo esc_attr('tb-alumnos'); ?>">
+                    <?php $alumnos_table->search_box(__('Buscar alumnos', 'tutorias-booking'), 'tb-alumnos-search'); ?>
+                    <?php $alumnos_table->display(); ?>
+                </form>
 
                 <form method="POST" onsubmit="return confirm('¿Eliminar todos los alumnos?');" class="tb-form">
                     <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
                     <button type="submit" name="tb_delete_all_alumnos" class="tb-button tb-button-danger">Eliminar Todos los Alumnos</button>
                 </form>
             <?php else: ?>
-                <p><em>No hay alumnos registrados.</em></p>
+                <p><em>No se pudo cargar la tabla de alumnos.</em></p>
             <?php endif; ?>
         <?php else: ?>
             <p><em>La tabla de alumnos no está disponible. Activa el plugin nuevamente.</em></p>

--- a/templates/admin/tutores.php
+++ b/templates/admin/tutores.php
@@ -19,7 +19,7 @@
                 <label for="tb_tutor_email">Email del tutor (Calendar ID)</label>
                 <input id="tb_tutor_email" name="tb_email" type="email" placeholder="Email (Calendar ID)" required>
             </div>
-            <button type="submit" class="tb-button">Agregar Tutor</button>
+            <button type="submit" name="tb_add_tutor" class="tb-button">Agregar Tutor</button>
         </form>
     </section>
 
@@ -37,51 +37,15 @@
 
     <section class="tb-section">
         <h2 class="tb-subtitle">Tutores Registrados</h2>
-        <table class="tb-table">
-            <thead>
-                <tr><th>Nombre</th><th>Email</th><th>Estado</th><th>Acciones</th></tr>
-            </thead>
-            <tbody>
-                <?php foreach ($tutores as $t): ?>
-                    <?php
-                        $tutor_id    = isset($t['id']) ? absint($t['id']) : 0;
-                        $has_token   = $tutor_id > 0 && !empty($tutores_tokens[$tutor_id]);
-                        $status_text = $has_token ? '✅ Conectado' : '❌ No conectado';
-                        $url = add_query_arg(
-                            [
-                                'page'     => 'tb-tutores',
-                                'action'   => 'tb_auth_google',
-                                'tutor_id' => $tutor_id,
-                            ],
-                            admin_url('admin.php')
-                        );
-                        $avail_url = add_query_arg(
-                            [
-                                'page'     => 'tb-tutores',
-                                'action'   => 'tb_assign_availability',
-                                'tutor_id' => $tutor_id,
-                            ],
-                            admin_url('admin.php')
-                        );
-                    ?>
-                    <tr>
-                        <td><?php echo esc_html($t['nombre']); ?></td>
-                        <td><?php echo esc_html($t['email']); ?></td>
-                        <td><?php echo esc_html($status_text); ?></td>
-                        <td>
-                            <a href="<?php echo esc_url($url); ?>" class="tb-link">Conectar Calendar</a>
-                            <span> | </span>
-                            <a href="<?php echo esc_url($avail_url); ?>" class="tb-link">Asignar Disponibilidad</a>
-                            <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este tutor?');">
-                                <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                <input type="hidden" name="tb_delete_tutor_id" value="<?php echo esc_attr($tutor_id); ?>">
-                                <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
-                            </form>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
+        <?php if (isset($tutors_table)) : ?>
+            <form method="post">
+                <input type="hidden" name="page" value="<?php echo esc_attr('tb-tutores'); ?>">
+                <?php $tutors_table->search_box(__('Buscar tutores', 'tutorias-booking'), 'tb-tutores-search'); ?>
+                <?php $tutors_table->display(); ?>
+            </form>
+        <?php else : ?>
+            <p><em>No se pudo cargar la tabla de tutores.</em></p>
+        <?php endif; ?>
     </section>
 
     <section class="tb-section">


### PR DESCRIPTION
## Summary
- add dedicated WP_List_Table implementations for tutors and alumnos with search, pagination, and bulk deletion support
- wire the new tables into the admin controller and loader while keeping existing form flows for imports and updates
- refresh admin templates to render the list tables and expose the native search box and controls

## Testing
- php -l includes/Admin/TutorsListTable.php
- php -l includes/Admin/AlumnosListTable.php
- php -l includes/Admin/AdminController.php
- php -l includes/Core/Loader.php
- php -l templates/admin/tutores.php
- php -l templates/admin/alumnos.php

------
https://chatgpt.com/codex/tasks/task_e_68c95790f9ec832fbadce55dcd0e6ee2