### PR TITLE
Add tabbed navigation to admin management page

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -17,6 +17,49 @@
     color: #333;
 }
 
+.tb-tabs-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 20px 0 0;
+}
+
+.tb-tabs-nav .tb-tab {
+    background-color: #f0f0f1;
+    border: 1px solid #dcdcde;
+    border-bottom: 3px solid transparent;
+    border-radius: 4px 4px 0 0;
+    color: #1d2327;
+    cursor: pointer;
+    font-weight: 600;
+    padding: 8px 16px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.tb-tabs-nav .tb-tab.is-active {
+    background-color: #fff;
+    border-color: #2271b1 #2271b1 #fff;
+    color: #2271b1;
+}
+
+.tb-tabs-nav .tb-tab:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.tb-tab-panel {
+    display: none;
+    border: 1px solid #dcdcde;
+    border-radius: 0 6px 6px 6px;
+    background: #fff;
+    padding: 20px;
+    margin-top: 0;
+}
+
+.tb-tab-panel.is-active {
+    display: block;
+}
+
 .tb-form {
     display: flex;
     flex-wrap: wrap;
@@ -117,14 +160,3 @@
     margin-bottom: 10px;
 }
 
-.tb-dropdown {
-    border: 1px solid #ddd;
-    padding: 20px;
-    margin-top: 20px;
-    border-radius: 6px;
-    background: #fff;
-}
-
-.tb-dropdown summary {
-    cursor: pointer;
-}

--- a/assets/js/admin-tabs.js
+++ b/assets/js/admin-tabs.js
@@ -1,0 +1,73 @@
+(function () {
+    const initTabs = function () {
+        const tabButtons = document.querySelectorAll('.tb-tabs-nav [data-tab]');
+        const tabPanels = document.querySelectorAll('.tb-tab-panel');
+
+        if (!tabButtons.length || !tabPanels.length) {
+            return;
+        }
+
+        const updateHiddenFields = function (tab) {
+            document.querySelectorAll('form input[name="active_tab"]').forEach(function (input) {
+                input.value = tab;
+            });
+        };
+
+        const setActiveTab = function (tab) {
+            tabButtons.forEach(function (button) {
+                const isActive = button.getAttribute('data-tab') === tab;
+                button.classList.toggle('is-active', isActive);
+                button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+                button.setAttribute('tabindex', isActive ? '0' : '-1');
+            });
+
+            tabPanels.forEach(function (panel) {
+                const isActive = panel.getAttribute('data-tab') === tab;
+                panel.classList.toggle('is-active', isActive);
+                panel.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+            });
+
+            updateHiddenFields(tab);
+        };
+
+        const getCurrentTab = function () {
+            const activeButton = Array.prototype.find.call(tabButtons, function (button) {
+                return button.classList.contains('is-active');
+            });
+
+            if (activeButton) {
+                return activeButton.getAttribute('data-tab');
+            }
+
+            return tabButtons[0] ? tabButtons[0].getAttribute('data-tab') : '';
+        };
+
+        tabButtons.forEach(function (button) {
+            button.addEventListener('click', function (event) {
+                event.preventDefault();
+                const tab = button.getAttribute('data-tab');
+                if (tab) {
+                    setActiveTab(tab);
+                }
+            });
+
+            button.addEventListener('keydown', function (event) {
+                if (event.key === ' ' || event.key === 'Spacebar' || event.key === 'Enter') {
+                    event.preventDefault();
+                    button.click();
+                }
+            });
+        });
+
+        const initialTab = getCurrentTab();
+        if (initialTab) {
+            setActiveTab(initialTab);
+        }
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTabs);
+    } else {
+        initTabs();
+    }
+})();

--- a/includes/Admin/AdminMenu.php
+++ b/includes/Admin/AdminMenu.php
@@ -27,6 +27,7 @@ class AdminMenu {
         $events_js    = TB_PLUGIN_DIR . 'assets/js/events.js';
         $utils_js     = TB_PLUGIN_DIR . 'assets/js/calendar-utils.js';
         $edit_js      = TB_PLUGIN_DIR . 'assets/js/admin-edit.js';
+        $tabs_js      = TB_PLUGIN_DIR . 'assets/js/admin-tabs.js';
 
         wp_enqueue_style(
             'tb-frontend',
@@ -47,6 +48,14 @@ class AdminMenu {
             TB_PLUGIN_URL . 'assets/js/admin.js',
             ['jquery'],
             file_exists($admin_js) ? filemtime($admin_js) : false,
+            true
+        );
+
+        wp_enqueue_script(
+            'tb-admin-tabs',
+            TB_PLUGIN_URL . 'assets/js/admin-tabs.js',
+            [],
+            file_exists($tabs_js) ? filemtime($tabs_js) : false,
             true
         );
 

--- a/templates/admin/admin-page.php
+++ b/templates/admin/admin-page.php
@@ -1,4 +1,37 @@
-<?php global $wpdb; ?>
+<?php
+global $wpdb;
+
+$valid_tabs = ['tutores', 'alumnos', 'citas'];
+$active_tab = 'tutores';
+
+if (isset($_REQUEST['active_tab'])) {
+    $requested_tab = sanitize_key(wp_unslash($_REQUEST['active_tab']));
+    if (in_array($requested_tab, $valid_tabs, true)) {
+        $active_tab = $requested_tab;
+    }
+}
+
+if (
+    isset($_POST['tb_import_tutores']) ||
+    isset($_POST['tb_delete_tutor_id']) ||
+    isset($_POST['tb_delete_all_tutores']) ||
+    (!empty($_POST['tb_nombre']) && !empty($_POST['tb_email']) && !isset($_POST['tb_add_alumno_reserva']))
+) {
+    $active_tab = 'tutores';
+} elseif (
+    isset($_POST['tb_add_alumno_reserva']) ||
+    isset($_POST['tb_import_alumnos']) ||
+    isset($_POST['tb_delete_alumno_id']) ||
+    isset($_POST['tb_delete_all_alumnos']) ||
+    isset($_POST['tb_update_alumno_id'])
+) {
+    $active_tab = 'alumnos';
+}
+
+if (isset($_GET['tb_search_student']) || isset($_GET['tb_page'])) {
+    $active_tab = 'alumnos';
+}
+?>
 <div class="tb-admin-wrapper">
 
     <?php foreach ($messages as $msg): ?>
@@ -7,186 +40,260 @@
         </div>
     <?php endforeach; ?>
 
-    <details class="tb-dropdown" open>
-        <summary class="tb-title">Gestión de Tutores</summary>
+    <nav class="tb-tabs-nav" role="tablist" aria-label="Gestión de Tutorías">
+        <button
+            type="button"
+            class="tb-tab <?php echo $active_tab === 'tutores' ? 'is-active' : ''; ?>"
+            data-tab="tutores"
+            id="tb-tab-button-tutores"
+            role="tab"
+            aria-controls="tb-tab-panel-tutores"
+            aria-selected="<?php echo $active_tab === 'tutores' ? 'true' : 'false'; ?>"
+            tabindex="<?php echo $active_tab === 'tutores' ? '0' : '-1'; ?>"
+        >
+            Gestión de Tutores
+        </button>
+        <button
+            type="button"
+            class="tb-tab <?php echo $active_tab === 'alumnos' ? 'is-active' : ''; ?>"
+            data-tab="alumnos"
+            id="tb-tab-button-alumnos"
+            role="tab"
+            aria-controls="tb-tab-panel-alumnos"
+            aria-selected="<?php echo $active_tab === 'alumnos' ? 'true' : 'false'; ?>"
+            tabindex="<?php echo $active_tab === 'alumnos' ? '0' : '-1'; ?>"
+        >
+            Gestión de Alumnos de Reserva
+        </button>
+        <button
+            type="button"
+            class="tb-tab <?php echo $active_tab === 'citas' ? 'is-active' : ''; ?>"
+            data-tab="citas"
+            id="tb-tab-button-citas"
+            role="tab"
+            aria-controls="tb-tab-panel-citas"
+            aria-selected="<?php echo $active_tab === 'citas' ? 'true' : 'false'; ?>"
+            tabindex="<?php echo $active_tab === 'citas' ? '0' : '-1'; ?>"
+        >
+            Gestión de Citas
+        </button>
+    </nav>
 
-    <section class="tb-section">
-        <h2 class="tb-subtitle">Tutores Registrados</h2>
+    <section
+        id="tb-tab-panel-tutores"
+        class="tb-tab-panel <?php echo $active_tab === 'tutores' ? 'is-active' : ''; ?>"
+        data-tab="tutores"
+        role="tabpanel"
+        aria-labelledby="tb-tab-button-tutores"
+        aria-hidden="<?php echo $active_tab === 'tutores' ? 'false' : 'true'; ?>"
+    >
+        <section class="tb-section">
+            <h2 class="tb-subtitle">Tutores Registrados</h2>
 
-        <form method="POST" class="tb-form">
-            <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-            <input name="tb_nombre" placeholder="Nombre" required>
-            <input name="tb_email" type="email" placeholder="Email (Calendar ID)" required>
-            <button type="submit" class="tb-button">Agregar Tutor</button>
-        </form>
-
-        <form method="POST" enctype="multipart/form-data" class="tb-form">
-            <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-            <input type="file" name="tb_tutores_file" accept=".xlsx" required>
-            <button type="submit" name="tb_import_tutores" class="tb-button">Importar Tutores</button>
-        </form>
-
-        <table class="tb-table">
-            <thead>
-                <tr><th>Nombre</th><th>Email</th><th>Estado</th><th>Acciones</th></tr>
-            </thead>
-            <tbody>
-                <?php foreach ($tutores as $t): ?>
-                    <?php $tok = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}tutores_tokens WHERE tutor_id=%d", $t->id)); ?>
-                    <?php $est = $tok ? '✅ Conectado' : '❌ No conectado'; ?>
-                    <?php $url = admin_url("admin.php?page=tb-tutores&action=tb_auth_google&tutor_id={$t->id}"); ?>
-                    <?php $avail_url = admin_url("admin.php?page=tb-tutores&action=tb_assign_availability&tutor_id={$t->id}"); ?>
-                    <tr>
-                        <td><?php echo esc_html($t->nombre); ?></td>
-                        <td><?php echo esc_html($t->email); ?></td>
-                        <td><?php echo $est; ?></td>
-                        <td>
-                            <a href="<?php echo esc_url($url); ?>" class="tb-link">Conectar Calendar</a>
-                            <span> | </span>
-                            <a href="<?php echo esc_url($avail_url); ?>" class="tb-link">Asignar Disponibilidad</a>
-                            <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este tutor?');">
-                                <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                <input type="hidden" name="tb_delete_tutor_id" value="<?php echo esc_attr($t->id); ?>">
-                                <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
-                            </form>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-            </tbody>
-        </table>
-
-        <form method="POST" onsubmit="return confirm('¿Eliminar todos los tutores?');" class="tb-form">
-            <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-            <button type="submit" name="tb_delete_all_tutores" class="tb-button tb-button-danger">Eliminar Todos los Tutores</button>
-        </form>
-    </section>
-    </details>
-
-    <details class="tb-dropdown">
-        <summary class="tb-title">Gestión de Alumnos de Reserva</summary>
-
-    <section class="tb-section">
-        <h2 class="tb-subtitle">Añadir Alumno a Reserva</h2>
-
-        <?php if ($table_exists): ?>
             <form method="POST" class="tb-form">
                 <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                <input type="text" name="tb_alumno_dni" placeholder="DNI del Alumno" required>
-                <input type="text" name="tb_alumno_nombre" placeholder="Nombre" required>
-                <input type="text" name="tb_alumno_apellido" placeholder="Apellido" required>
-                <input type="email" name="tb_alumno_email" placeholder="Email del Alumno" required>
-                <label><input type="checkbox" name="tb_alumno_online" value="1"> Online</label>
-                <label><input type="checkbox" name="tb_alumno_presencial" value="1"> Presencial</label>
-                <button type="submit" name="tb_add_alumno_reserva" class="tb-button">Añadir Alumno</button>
+                <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                <input name="tb_nombre" placeholder="Nombre" required>
+                <input name="tb_email" type="email" placeholder="Email (Calendar ID)" required>
+                <button type="submit" class="tb-button">Agregar Tutor</button>
             </form>
 
             <form method="POST" enctype="multipart/form-data" class="tb-form">
                 <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                <input type="file" name="tb_alumnos_file" accept=".xlsx" required>
-                <button type="submit" name="tb_import_alumnos" class="tb-button">Importar Alumnos</button>
+                <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                <input type="file" name="tb_tutores_file" accept=".xlsx" required>
+                <button type="submit" name="tb_import_tutores" class="tb-button">Importar Tutores</button>
             </form>
-        <?php else: ?>
-            <p><em>El formulario no está disponible. Activa el plugin nuevamente.</em></p>
-        <?php endif; ?>
+
+            <table class="tb-table">
+                <thead>
+                    <tr><th>Nombre</th><th>Email</th><th>Estado</th><th>Acciones</th></tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($tutores as $t): ?>
+                        <?php $tok = $wpdb->get_row($wpdb->prepare("SELECT * FROM {$wpdb->prefix}tutores_tokens WHERE tutor_id=%d", $t->id)); ?>
+                        <?php $est = $tok ? '✅ Conectado' : '❌ No conectado'; ?>
+                        <?php $url = admin_url("admin.php?page=tb-tutores&action=tb_auth_google&tutor_id={$t->id}"); ?>
+                        <?php $avail_url = admin_url("admin.php?page=tb-tutores&action=tb_assign_availability&tutor_id={$t->id}"); ?>
+                        <tr>
+                            <td><?php echo esc_html($t->nombre); ?></td>
+                            <td><?php echo esc_html($t->email); ?></td>
+                            <td><?php echo $est; ?></td>
+                            <td>
+                                <a href="<?php echo esc_url($url); ?>" class="tb-link">Conectar Calendar</a>
+                                <span> | </span>
+                                <a href="<?php echo esc_url($avail_url); ?>" class="tb-link">Asignar Disponibilidad</a>
+                                <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este tutor?');">
+                                    <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                                    <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                                    <input type="hidden" name="tb_delete_tutor_id" value="<?php echo esc_attr($t->id); ?>">
+                                    <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
+                                </form>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
+
+            <form method="POST" onsubmit="return confirm('¿Eliminar todos los tutores?');" class="tb-form">
+                <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                <button type="submit" name="tb_delete_all_tutores" class="tb-button tb-button-danger">Eliminar Todos los Tutores</button>
+            </form>
+        </section>
     </section>
 
-    <section class="tb-section">
-        <h2 class="tb-subtitle">Alumnos en la Tabla de Reserva</h2>
+    <section
+        id="tb-tab-panel-alumnos"
+        class="tb-tab-panel <?php echo $active_tab === 'alumnos' ? 'is-active' : ''; ?>"
+        data-tab="alumnos"
+        role="tabpanel"
+        aria-labelledby="tb-tab-button-alumnos"
+        aria-hidden="<?php echo $active_tab === 'alumnos' ? 'false' : 'true'; ?>"
+    >
+        <section class="tb-section">
+            <h2 class="tb-subtitle">Añadir Alumno a Reserva</h2>
 
-        <?php if ($table_exists): ?>
-            <form method="GET" class="tb-form">
-                <input type="hidden" name="page" value="tb-tutores">
-                <input type="text" name="tb_search_student" placeholder="Buscar por DNI o Nombre" value="<?php echo esc_attr($search_student); ?>">
-                <button type="submit" class="tb-button">Buscar</button>
-                <?php if (!empty($search_student)): ?>
-                    <a href="<?php echo esc_url(admin_url('admin.php?page=tb-tutores')); ?>" class="tb-button">Limpiar</a>
-                <?php endif; ?>
-            </form>
-
-            <?php if (!empty($alumnos_reserva)): ?>
-                <table class="tb-table">
-                    <thead>
-                        <tr><th>ID</th><th>DNI</th><th>Nombre</th><th>Apellido</th><th>Email</th><th>Online</th><th>Presencial</th><th>Acciones</th></tr>
-                    </thead>
-                    <tbody>
-                        <?php foreach ($alumnos_reserva as $alumno): ?>
-                            <tr>
-                                <td><?php echo esc_html($alumno->id); ?></td>
-                                <td><?php echo esc_html($alumno->dni); ?></td>
-                                <td><?php echo esc_html($alumno->nombre); ?></td>
-                                <td><?php echo esc_html($alumno->apellido); ?></td>
-                                <td><?php echo esc_html($alumno->email); ?></td>
-                                <td><input type="checkbox" name="tb_online" value="1" form="tb_update_<?php echo esc_attr($alumno->id); ?>" <?php checked($alumno->online); ?>></td>
-                                <td><input type="checkbox" name="tb_presencial" value="1" form="tb_update_<?php echo esc_attr($alumno->id); ?>" <?php checked($alumno->presencial); ?>></td>
-                                <td>
-                                    <form method="POST" id="tb_update_<?php echo esc_attr($alumno->id); ?>" class="tb-inline-form">
-                                        <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                        <input type="hidden" name="tb_update_alumno_id" value="<?php echo esc_attr($alumno->id); ?>">
-                                        <button type="submit" class="tb-button">Actualizar</button>
-                                    </form>
-                                    <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este alumno?');">
-                                        <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                                        <input type="hidden" name="tb_delete_alumno_id" value="<?php echo esc_attr($alumno->id); ?>">
-                                        <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
-                                    </form>
-                                </td>
-                            </tr>
-                        <?php endforeach; ?>
-                    </tbody>
-                </table>
-
-                <?php if (empty($search_student) && $total_pages > 1): ?>
-                    <div class="tb-pagination">
-                        <?php for ($i = 1; $i <= $total_pages; $i++): ?>
-                            <a class="tb-button <?php echo ($i === $current_page) ? 'active' : ''; ?>" href="<?php echo esc_url('admin.php?page=tb-tutores&tb_page=' . $i); ?>"><?php echo esc_html($i); ?></a>
-                        <?php endfor; ?>
-                    </div>
-                <?php endif; ?>
-
-                <form method="POST" onsubmit="return confirm('¿Eliminar todos los alumnos?');" class="tb-form">
+            <?php if ($table_exists): ?>
+                <form method="POST" class="tb-form">
                     <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
-                    <button type="submit" name="tb_delete_all_alumnos" class="tb-button tb-button-danger">Eliminar Todos los Alumnos</button>
+                    <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                    <input type="text" name="tb_alumno_dni" placeholder="DNI del Alumno" required>
+                    <input type="text" name="tb_alumno_nombre" placeholder="Nombre" required>
+                    <input type="text" name="tb_alumno_apellido" placeholder="Apellido" required>
+                    <input type="email" name="tb_alumno_email" placeholder="Email del Alumno" required>
+                    <label><input type="checkbox" name="tb_alumno_online" value="1"> Online</label>
+                    <label><input type="checkbox" name="tb_alumno_presencial" value="1"> Presencial</label>
+                    <button type="submit" name="tb_add_alumno_reserva" class="tb-button">Añadir Alumno</button>
+                </form>
+
+                <form method="POST" enctype="multipart/form-data" class="tb-form">
+                    <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                    <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                    <input type="file" name="tb_alumnos_file" accept=".xlsx" required>
+                    <button type="submit" name="tb_import_alumnos" class="tb-button">Importar Alumnos</button>
                 </form>
             <?php else: ?>
-                <p><em>No hay alumnos registrados.</em></p>
+                <p><em>El formulario no está disponible. Activa el plugin nuevamente.</em></p>
             <?php endif; ?>
-        <?php else: ?>
-            <p><em>La tabla de alumnos no está disponible. Activa el plugin nuevamente.</em></p>
-        <?php endif; ?>
+        </section>
+
+        <section class="tb-section">
+            <h2 class="tb-subtitle">Alumnos en la Tabla de Reserva</h2>
+
+            <?php if ($table_exists): ?>
+                <form method="GET" class="tb-form">
+                    <input type="hidden" name="page" value="tb-tutores">
+                    <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                    <input type="text" name="tb_search_student" placeholder="Buscar por DNI o Nombre" value="<?php echo esc_attr($search_student); ?>">
+                    <button type="submit" class="tb-button">Buscar</button>
+                    <?php if (!empty($search_student)): ?>
+                        <a href="<?php echo esc_url(add_query_arg('active_tab', 'alumnos', admin_url('admin.php?page=tb-tutores'))); ?>" class="tb-button">Limpiar</a>
+                    <?php endif; ?>
+                </form>
+
+                <?php if (!empty($alumnos_reserva)): ?>
+                    <table class="tb-table">
+                        <thead>
+                            <tr><th>ID</th><th>DNI</th><th>Nombre</th><th>Apellido</th><th>Email</th><th>Online</th><th>Presencial</th><th>Acciones</th></tr>
+                        </thead>
+                        <tbody>
+                            <?php foreach ($alumnos_reserva as $alumno): ?>
+                                <tr>
+                                    <td><?php echo esc_html($alumno->id); ?></td>
+                                    <td><?php echo esc_html($alumno->dni); ?></td>
+                                    <td><?php echo esc_html($alumno->nombre); ?></td>
+                                    <td><?php echo esc_html($alumno->apellido); ?></td>
+                                    <td><?php echo esc_html($alumno->email); ?></td>
+                                    <td><input type="checkbox" name="tb_online" value="1" form="tb_update_<?php echo esc_attr($alumno->id); ?>" <?php checked($alumno->online); ?>></td>
+                                    <td><input type="checkbox" name="tb_presencial" value="1" form="tb_update_<?php echo esc_attr($alumno->id); ?>" <?php checked($alumno->presencial); ?>></td>
+                                    <td>
+                                        <form method="POST" id="tb_update_<?php echo esc_attr($alumno->id); ?>" class="tb-inline-form">
+                                            <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                                            <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                                            <input type="hidden" name="tb_update_alumno_id" value="<?php echo esc_attr($alumno->id); ?>">
+                                            <button type="submit" class="tb-button">Actualizar</button>
+                                        </form>
+                                        <form method="POST" class="tb-inline-form" onsubmit="return confirm('¿Eliminar este alumno?');">
+                                            <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                                            <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                                            <input type="hidden" name="tb_delete_alumno_id" value="<?php echo esc_attr($alumno->id); ?>">
+                                            <button type="submit" class="tb-button tb-button-danger">Eliminar</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        </tbody>
+                    </table>
+
+                    <?php if (empty($search_student) && $total_pages > 1): ?>
+                        <div class="tb-pagination">
+                            <?php for ($i = 1; $i <= $total_pages; $i++): ?>
+                                <?php $page_url = add_query_arg(
+                                    [
+                                        'page'       => 'tb-tutores',
+                                        'tb_page'    => $i,
+                                        'active_tab' => 'alumnos',
+                                    ],
+                                    admin_url('admin.php')
+                                ); ?>
+                                <a class="tb-button <?php echo ($i === $current_page) ? 'active' : ''; ?>" href="<?php echo esc_url($page_url); ?>"><?php echo esc_html($i); ?></a>
+                            <?php endfor; ?>
+                        </div>
+                    <?php endif; ?>
+
+                    <form method="POST" onsubmit="return confirm('¿Eliminar todos los alumnos?');" class="tb-form">
+                        <?php wp_nonce_field('tb_admin_action', 'tb_admin_nonce'); ?>
+                        <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                        <button type="submit" name="tb_delete_all_alumnos" class="tb-button tb-button-danger">Eliminar Todos los Alumnos</button>
+                    </form>
+                <?php else: ?>
+                    <p><em>No hay alumnos registrados.</em></p>
+                <?php endif; ?>
+            <?php else: ?>
+                <p><em>La tabla de alumnos no está disponible. Activa el plugin nuevamente.</em></p>
+            <?php endif; ?>
+        </section>
     </section>
-    </details>
 
-    <details class="tb-dropdown">
-        <summary class="tb-title">Gestión de Citas</summary>
+    <section
+        id="tb-tab-panel-citas"
+        class="tb-tab-panel <?php echo $active_tab === 'citas' ? 'is-active' : ''; ?>"
+        data-tab="citas"
+        role="tabpanel"
+        aria-labelledby="tb-tab-button-citas"
+        aria-hidden="<?php echo $active_tab === 'citas' ? 'false' : 'true'; ?>"
+    >
+        <section class="tb-section">
+            <form id="tb-events-form" class="tb-form">
+                <input type="hidden" name="active_tab" value="<?php echo esc_attr($active_tab); ?>">
+                <select id="tb_events_tutor">
+                    <option value="">Todos los tutores</option>
+                    <?php foreach ($tutores as $t): ?>
+                        <option value="<?php echo esc_attr($t->id); ?>"><?php echo esc_html($t->nombre); ?></option>
+                    <?php endforeach; ?>
+                </select>
+                <input type="text" id="tb_events_student" placeholder="DNI o nombre del alumno (opcional)">
+                <select id="tb_events_modalidad">
+                    <option value="">Todos</option>
+                    <option value="online">online</option>
+                    <option value="presencial">presencial</option>
+                </select>
+                <input type="date" id="tb_events_start" placeholder="Fecha inicio (opcional)">
+                <input type="date" id="tb_events_end" placeholder="Fecha fin (opcional)">
+                <button type="submit" class="tb-button">Ver Citas</button>
+                <button type="button" id="tb_export_events" class="tb-button">Exportar XLSX</button>
+            </form>
 
-    <section class="tb-section">
-        <form id="tb-events-form" class="tb-form">
-            <select id="tb_events_tutor">
-                <option value="">Todos los tutores</option>
-                <?php foreach ($tutores as $t): ?>
-                    <option value="<?php echo esc_attr($t->id); ?>"><?php echo esc_html($t->nombre); ?></option>
-                <?php endforeach; ?>
-            </select>
-            <input type="text" id="tb_events_student" placeholder="DNI o nombre del alumno (opcional)">
-            <select id="tb_events_modalidad">
-                <option value="">Todos</option>
-                <option value="online">online</option>
-                <option value="presencial">presencial</option>
-            </select>
-            <input type="date" id="tb_events_start" placeholder="Fecha inicio (opcional)">
-            <input type="date" id="tb_events_end" placeholder="Fecha fin (opcional)">
-            <button type="submit" class="tb-button">Ver Citas</button>
-            <button type="button" id="tb_export_events" class="tb-button">Exportar XLSX</button>
-        </form>
-
-        <table id="tb-events-table" class="tb-table">
-            <thead>
-                <tr><th>Usuario</th><th>DNI</th><th>Email</th><th>Tutor</th><th>Tramo</th><th>Modalidad</th><th>Cita</th><th>Acciones</th></tr>
-            </thead>
-            <tbody></tbody>
-        </table>
+            <table id="tb-events-table" class="tb-table">
+                <thead>
+                    <tr><th>Usuario</th><th>DNI</th><th>Email</th><th>Tutor</th><th>Tramo</th><th>Modalidad</th><th>Cita</th><th>Acciones</th></tr>
+                </thead>
+                <tbody></tbody>
+            </table>
+        </section>
     </section>
-    </details>
+
     <div id="tb_edit_modal" class="tb-slots-overlay" style="display:none">
         <div class="tb-slots-content">
             <select id="tb_edit_tutor"></select>


### PR DESCRIPTION
## Summary
- replace the admin page dropdown sections with a tabbed layout that keeps the active tab after form submissions
- refresh the admin CSS to support the new tab navigation and panels while removing the unused dropdown styles
- add a lightweight vanilla script to handle tab switching and enqueue it with the other admin assets

## Testing
- php -l templates/admin/admin-page.php

------
https://chatgpt.com/codex/tasks/task_e_68ca74b45234832fa20c16d7559dd53a